### PR TITLE
Fix CIWS target tracking and firing power gating

### DIFF
--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -82,65 +82,35 @@ public abstract class TileEntityTurretBase extends TileEntity {
 	@Override
 	public void updateEntity() {
 
-		//if(this instanceof TileEntityTurretCIWS) {
-		//	System.out.println("Power: " + ((TileEntityTurretCIWS)this).getPower());
-		//}
+		boolean isCiws = this instanceof TileEntityTurretCIWS;
+		boolean hasPower = !isCiws || ((TileEntityTurretCIWS) this).hasPower();
 
-
-		//TODOne if you do not power turret, it will not shoot and rotate.
-
-		System.out.println(
-			"AI=" + isAI +
-				" remote=" + worldObj.isRemote +
-				" hasPower=" +
-				(this instanceof TileEntityTurretCIWS
-					? ((TileEntityTurretCIWS)this).hasPower()
-					: "N/A")
-		);
-
-		if(!worldObj.isRemote && isAI && (
-			!(this instanceof TileEntityTurretCIWS)
-				|| ((TileEntityTurretCIWS)this).hasPower()
-		))
-
-			System.out.println("ENTERED AI BLOCK");
-
-
-			//&& canOperate()) bricks turret rotation even when having power so we cannot do that here
-			//we only care about the AI part of our automated close in weapon system.
-
+		if(!worldObj.isRemote && isAI && hasPower) {
 			Object[] iter = worldObj.loadedEntityList.toArray();
 			double radius = 1000;
 
-			if(this instanceof TileEntityTurretCIWS)
+			if(isCiws)
 				radius *= 100;
 			Entity target = null;
-			for (int i = 0; i < iter.length; i++)
-			{
+			for (int i = 0; i < iter.length; i++) {
 				Entity e = (Entity) iter[i];
-				if (isInSight(e))
-				{
+				if (isInSight(e)) {
 					double distance = e.getDistanceSq(xCoord + 0.5, yCoord + 0.5, zCoord + 0.5);
-					if (distance < radius)
-					{
+					if (distance < radius) {
 						radius = distance;
 						target = e;
 					}
 				}
 			}
 
-			if(target != null ) { //&& canOperate() we also cannot do that here.
-				//I wanna try && te.getPower() but te isn't defined here. Let's try something else.
-
-				//System.out.println("TARGET = " + target);
-
+			if(target != null) {
 				Vec3 turret = Vec3.createVectorHelper(target.posX - (xCoord + 0.5), target.posY + target.getEyeHeight() - (yCoord + 1), target.posZ - (zCoord + 0.5));
 
-				if(this instanceof TileEntityTurretCIWS ) {
+				if(isCiws) {
 					turret = Vec3.createVectorHelper(target.posX - (xCoord + 0.5), target.posY + target.getEyeHeight() - (yCoord + 1.5), target.posZ - (zCoord + 0.5));
 				}
 
-				rotationPitch = -Math.asin(turret.yCoord/turret.lengthVector()) * 180 / Math.PI;
+				rotationPitch = -Math.asin(turret.yCoord / turret.lengthVector()) * 180 / Math.PI;
 				rotationYaw = -Math.atan2(turret.xCoord, turret.zCoord) * 180 / Math.PI;
 
 				if(rotationPitch < -60)
@@ -148,38 +118,31 @@ public abstract class TileEntityTurretBase extends TileEntity {
 				if(rotationPitch > 30)
 					rotationPitch = 30;
 
-				if(!worldObj.isRemote) {
-					worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
-				}
+				worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 
-				if(!worldObj.isRemote) {
-					PacketDispatcher.wrapper.sendToAll(
-						new TETurretPacket(
-							xCoord,
-							yCoord,
-							zCoord,
-							rotationYaw,
-							rotationPitch
-						)
-					);
-				}
+				PacketDispatcher.wrapper.sendToAll(
+					new TETurretPacket(
+						xCoord,
+						yCoord,
+						zCoord,
+						rotationYaw,
+						rotationPitch
+					)
+				);
 
 				use++;
 
 				if(worldObj.getBlock(xCoord, yCoord, zCoord) instanceof TurretBase && ammo > 0) {
-					//System.out.println(
-					//	"SHOOT CHECK ammo=" + ammo +
-					//		" yaw=" + rotationYaw +
-					//		" pitch=" + rotationPitch
-					//);
 					if(((TurretBase)worldObj.getBlock(xCoord, yCoord, zCoord)).executeHoldAction(worldObj, use, rotationYaw, rotationPitch, xCoord, yCoord, zCoord))
 						ammo--;
 				}
-
 			} else {
 				use = 0;
 			}
+		} else if(!worldObj.isRemote) {
+			use = 0;
 		}
+	}
 
 
 


### PR DESCRIPTION
### Motivation
- The CIWS turret AI was not turning toward targets correctly and could behave incorrectly when unpowered, so the goal is to make CIWS only acquire/aim when powered and keep firing strictly gated by ammo.
- Desired behavior is: no turning or firing when unpowered, turning when powered even if out of ammo, and firing only when both powered and `ammo > 0`.

### Description
- Reworked `TileEntityTurretBase.updateEntity()` to compute `isCiws` and `hasPower` and to scope the AI logic behind `if(!worldObj.isRemote && isAI && hasPower)` so CIWS only acquires/aims when powered.
- Kept target acquisition and aiming independent of `ammo`, so a powered CIWS will still rotate toward targets even with zero ammo, while firing is still conditioned on `ammo > 0` before calling `executeHoldAction`.
- Removed redundant per-check server guards and some debug noise, and consolidated the block update / `TETurretPacket` send to the AI branch where aiming occurs.
- Applied formatting/flow fixes (braces and loop style) to restore correct control flow and prevent the prior accidental fall-through that left CIWS static while powered.

### Testing
- Attempted to compile with `./gradlew -q compileJava` to validate the change, but the build failed in this environment due to a Gradle/Java mismatch (`Could not determine java version from '25.0.2'`).
- No automated tests ran successfully in this environment because compilation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a150c0509848323a18b47ec1d7a5631)