### PR TITLE
Require CIWS power before targeting and firing

### DIFF
--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -43,7 +43,7 @@ public abstract class TileEntityTurretBase extends TileEntity {
 
 		//TODOne if you do not power turret, it will not shoot and rotate.
 
-		if(isAI) { //&& canOperate()) bricks turret rotation even when having power so we cannot do that here
+		if(isAI && canOperate()) {
 			//we only care about the AI part of our automated close in weapon system.
 
 			Object[] iter = worldObj.loadedEntityList.toArray();
@@ -66,7 +66,7 @@ public abstract class TileEntityTurretBase extends TileEntity {
 				}
 			}
 
-			if(target != null ) { //&& canOperate() we also cannot do that here.
+			if(target != null ) {
 
 				Vec3 turret = Vec3.createVectorHelper(target.posX - (xCoord + 0.5), target.posY + target.getEyeHeight() - (yCoord + 1), target.posZ - (zCoord + 0.5));
 

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
@@ -29,6 +29,12 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 	//				net.minecraftforge.common.util.ForgeDirection.UP
 	//			);
 
+
+	@Override
+	protected boolean canOperate() {
+		return hasPower();
+	}
+
 	@Override
 	public void updateEntity() {
 
@@ -111,7 +117,7 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 	}
 
 	public boolean hasPower() {
-		return power > 0;
+		return power >= consumption;
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation
- Ensure the CIWS does not acquire, track, or fire at targets when it lacks sufficient energy, matching how other energy-using machines behave.
- Remove ambiguity around partial energy states by using the same consumption-based check used elsewhere in machine code.

### Description
- Gate turret AI in `TileEntityTurretBase` by changing the AI entry condition to `if (isAI && canOperate())` so specific turrets can opt into operation checks without changing base behavior.
- Override `canOperate()` in `TileEntityTurretCIWS` to return `hasPower()` so the CIWS will not look at or engage targets when not powered.
- Change CIWS energy semantics in `TileEntityTurretCIWS#hasPower()` from `power > 0` to `power >= consumption` to require at least one tick's worth of energy before operating.
- Preserve existing update and consume behavior in `TileEntityTurretCIWS#updateEntity()`; no other firing/aiming logic was modified.

### Testing
- Ran `./gradlew -q compileJava` to validate compilation; this failed due to an environment Gradle/Java mismatch (`Could not determine java version from '25.0.2'`) and not because of the code changes.
- No further automated tests were executed in this environment due to the toolchain failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15118a7d74832394614498c268d96c)