### PR TITLE
CIWS: stop spinning/shooting without power and consume power per shot

### DIFF
--- a/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
+++ b/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
@@ -37,14 +37,10 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 		TileEntityTurretCIWS te = (TileEntityTurretCIWS)world.getTileEntity(x, y, z);
 		boolean flag = false;
 
-		//if (te.canOperate()) //so apparently this does nothing apparently
-		if(te.hasPower())
-
-		//todo if canOperate() then literally everything in this block, then maybe turret rotation won't be fucked?
-
-		//TODO if you do not power turret, it will not shoot and rotate.
-
-
+		if(!te.hasPower()) {
+			te.spin = 0;
+			return false;
+		}
 
 		if(pitch < -60)
 			pitch = -60;
@@ -56,7 +52,7 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 		if(te.spin < 35)
 			te.spin += 5;
 
-		if(te.spin > 25 && i % 2 == 0) {
+		if(te.spin > 25 && i % 2 == 0 && te.hasPowerForShot()) {
 			Vec3 vector = Vec3.createVectorHelper(
 				-Math.sin(yaw / 180.0F * (float) Math.PI) * Math.cos(pitch / 180.0F * (float) Math.PI),
 				-Math.sin(pitch / 180.0F * (float) Math.PI),
@@ -81,8 +77,7 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 				//TODO add back in
 			}
 
-			//te.consumePower(250);
-			//I don't know that we should do that here?
+			te.consumeShotPower();
 
 			world.playSoundEffect(x, y, z, "hbm:weapon.gun_m61a1_snd", 5.0F, 1.25F);
 

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -46,6 +46,11 @@ public abstract class TileEntityTurretBase extends TileEntity {
 		if(isAI) { //&& canOperate()) bricks turret rotation even when having power so we cannot do that here
 			//we only care about the AI part of our automated close in weapon system.
 
+			if(this instanceof TileEntityTurretCIWS && !((TileEntityTurretCIWS)this).hasPower()) {
+				use = 0;
+				return;
+			}
+
 			Object[] iter = worldObj.loadedEntityList.toArray();
 			double radius = 1000;
 
@@ -67,6 +72,7 @@ public abstract class TileEntityTurretBase extends TileEntity {
 			}
 
 			if(target != null ) { //&& canOperate() we also cannot do that here.
+
 
 				Vec3 turret = Vec3.createVectorHelper(target.posX - (xCoord + 0.5), target.posY + target.getEyeHeight() - (yCoord + 1), target.posZ - (zCoord + 0.5));
 

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
@@ -29,6 +29,7 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 	//				net.minecraftforge.common.util.ForgeDirection.UP
 	//			);
 
+
 	@Override
 	public void updateEntity() {
 
@@ -43,14 +44,6 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 
 		if(!worldObj.isRemote) {
 			updateConnections();
-
-			if(hasPower()) {
-				this.power -= consumption;
-
-				if(this.power < 0) {
-					this.power = 0;
-				}
-			}
 
 
 			if(spin > 0)
@@ -112,6 +105,14 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 
 	public boolean hasPower() {
 		return power > 0;
+	}
+
+	public boolean hasPowerForShot() {
+		return power >= POWER_PER_SHOT;
+	}
+
+	public void consumeShotPower() {
+		consumePower(POWER_PER_SHOT);
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation

- Prevent the CIWS turret from rotating or firing when it has no power and ensure shots consume a fixed amount of energy.

### Description

- Added `hasPowerForShot()` and `consumeShotPower()` to `TileEntityTurretCIWS` and replaced ad-hoc power checks with a per-shot consumption constant `POWER_PER_SHOT`.
- Updated `TurretCIWS.executeHoldAction` to immediately stop spinning and return when the CIWS has no power and to only fire when `hasPowerForShot()` is true, calling `consumeShotPower()` on each shot.
- Adjusted `TileEntityTurretBase.updateEntity` so AI-controlled CIWS turrets early-return when out of power to avoid unwanted rotation/operation, and removed continuous power drain from `TileEntityTurretCIWS.updateEntity` so power is consumed per shot instead.

### Testing

- Built the project with `gradlew build` and the build completed successfully with no compilation errors.
- Ran available automated tests via the build which succeeded (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15118a7d74832394614498c268d96c)