### PR TITLE
Require turret power for AI rotation and per-shot firing; add CIWS power accounting

### DIFF
--- a/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
+++ b/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
@@ -37,14 +37,10 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 		TileEntityTurretCIWS te = (TileEntityTurretCIWS)world.getTileEntity(x, y, z);
 		boolean flag = false;
 
-		//if (te.canOperate()) //so apparently this does nothing apparently
-		if(te.hasPower())
-
-		//todo if canOperate() then literally everything in this block, then maybe turret rotation won't be fucked?
-
-		//TODO if you do not power turret, it will not shoot and rotate.
-
-
+		if(!te.hasPower()) {
+			te.spin = 0;
+			return false;
+		}
 
 		if(pitch < -60)
 			pitch = -60;
@@ -56,7 +52,7 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 		if(te.spin < 35)
 			te.spin += 5;
 
-		if(te.spin > 25 && i % 2 == 0) {
+		if(te.spin > 25 && i % 2 == 0 && te.hasPowerForShot()) {
 			Vec3 vector = Vec3.createVectorHelper(
 				-Math.sin(yaw / 180.0F * (float) Math.PI) * Math.cos(pitch / 180.0F * (float) Math.PI),
 				-Math.sin(pitch / 180.0F * (float) Math.PI),
@@ -81,8 +77,7 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 				//TODO add back in
 			}
 
-			//te.consumePower(250);
-			//I don't know that we should do that here?
+			te.consumeShotPower();
 
 			world.playSoundEffect(x, y, z, "hbm:weapon.gun_m61a1_snd", 5.0F, 1.25F);
 

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -43,8 +43,9 @@ public abstract class TileEntityTurretBase extends TileEntity {
 
 		//TODOne if you do not power turret, it will not shoot and rotate.
 
-		if(isAI) { //&& canOperate()) bricks turret rotation even when having power so we cannot do that here
+		if(isAI && canOperate()) {
 			//we only care about the AI part of our automated close in weapon system.
+
 
 			Object[] iter = worldObj.loadedEntityList.toArray();
 			double radius = 1000;
@@ -66,7 +67,8 @@ public abstract class TileEntityTurretBase extends TileEntity {
 				}
 			}
 
-			if(target != null ) { //&& canOperate() we also cannot do that here.
+			if(target != null ) {
+
 
 				Vec3 turret = Vec3.createVectorHelper(target.posX - (xCoord + 0.5), target.posY + target.getEyeHeight() - (yCoord + 1), target.posZ - (zCoord + 0.5));
 

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretCIWS.java
@@ -29,30 +29,22 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 	//				net.minecraftforge.common.util.ForgeDirection.UP
 	//			);
 
+
+	@Override
+	protected boolean canOperate() {
+		return hasPower();
+	}
+
 	@Override
 	public void updateEntity() {
 
-		super.updateEntity();
-
-		//this.ammo = 100;
-		//??? what does this do other than inf ammo?
-
-
-
-
-
 		if(!worldObj.isRemote) {
 			updateConnections();
+		}
 
-			if(hasPower()) {
-				this.power -= consumption;
+		super.updateEntity();
 
-				if(this.power < 0) {
-					this.power = 0;
-				}
-			}
-
-
+		if(!worldObj.isRemote) {
 			if(spin > 0)
 				spin -= 1;
 
@@ -112,6 +104,14 @@ public class TileEntityTurretCIWS extends TileEntityTurretBase implements IEnerg
 
 	public boolean hasPower() {
 		return power > 0;
+	}
+
+	public boolean hasPowerForShot() {
+		return power >= POWER_PER_SHOT;
+	}
+
+	public void consumeShotPower() {
+		consumePower(POWER_PER_SHOT);
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation

- Ensure CIWS turrets stop rotating and firing when they lack power and avoid consuming power unless a shot is actually fired.
- Prevent AI-controlled turrets from attempting to operate when they cannot (no power), fixing errant rotation behavior.

### Description

- Added an early power check to `TurretCIWS.executeHoldAction` that zeroes `spin` and aborts when the tile entity has no power.
- Require `te.hasPowerForShot()` before performing a shot and replaced the inline power consume with `te.consumeShotPower()` in `TurretCIWS` so power is only deducted per shot.
- Introduced power bookkeeping in `TileEntityTurretCIWS` including `power`, `maxPower`, `POWER_PER_SHOT`, `hasPowerForShot()`, and `consumeShotPower()`, and moved connection updates to server-side.
- Made `TileEntityTurretCIWS.canOperate()` return `hasPower()` and changed `TileEntityTurretBase.updateEntity()` to only run AI targeting when `isAI && canOperate()`, preventing AI rotation when unpowered.

### Testing

- Ran the project automated build with `./gradlew build` which completed successfully.
- No failing automated tests were reported by the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15118a7d74832394614498c268d96c)