### PR TITLE
Sync turret yaw/pitch to clients so CIWS visually tracks targets

### DIFF
--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -9,6 +9,7 @@ import com.hbm.lib.Library;
 import com.hbm.packet.PacketDispatcher;
 import com.hbm.packet.TETurretPacket;
 
+import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.Entity;
@@ -44,6 +45,7 @@ public abstract class TileEntityTurretBase extends TileEntity {
 		//TODOne if you do not power turret, it will not shoot and rotate.
 
 		if(isAI && canOperate()) {
+
 			//we only care about the AI part of our automated close in weapon system.
 
 
@@ -93,6 +95,12 @@ public abstract class TileEntityTurretBase extends TileEntity {
 
 			} else {
 				use = 0;
+			}
+			if(!worldObj.isRemote && (rotationYaw != lastYaw || rotationPitch != lastPitch)) {
+				PacketDispatcher.wrapper.sendToAllAround(new TETurretPacket(xCoord, yCoord, zCoord, rotationYaw, rotationPitch),
+					new TargetPoint(worldObj.provider.dimensionId, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5, 128));
+				lastYaw = rotationYaw;
+				lastPitch = rotationPitch;
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation

- Fix visual desynchronization where the CIWS would still kill targets but not visually track them on clients because aim angles were only updated server-side. 
- Mirror the behavior of the GUI-driven `turret_howard` by making client rendering follow the server aim state while keeping power gating semantics so an unpowered CIWS does not track.

### Description

- Added server-side broadcast of aim state from `TileEntityTurretBase` by sending a `TETurretPacket` with yaw/pitch when the rotation changes using a nearby `TargetPoint` (128 block radius). 
- Only sends updates when `!worldObj.isRemote` and aim values differ from the stored `lastYaw`/`lastPitch`, and the send is executed inside the existing `if(isAI && canOperate())` block so power gating remains unchanged. 
- Introduced `TargetPoint` import and stored the sent values in `lastYaw`/`lastPitch` to avoid redundant network traffic. 
- No targeting or firing logic was modified; this change only synchronizes orientation for rendering (file changed: `src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java`).

### Testing

- Created PR metadata using `make_pr`, which completed successfully. 
- No automated build or unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e435aa48323b566f1c7e88d44fa)