### PR TITLE
Sync turret orientation to clients with TETurretPacket

### DIFF
--- a/src/main/java/com/hbm/packet/PacketDispatcher.java
+++ b/src/main/java/com/hbm/packet/PacketDispatcher.java
@@ -82,6 +82,7 @@ public class PacketDispatcher {
 		wrapper.registerMessage(BiomeSyncPacket.Handler.class, BiomeSyncPacket.class, i++, Side.CLIENT);
 
 		//Tile sync
+		wrapper.registerMessage(TETurretPacket.Handler.class, TETurretPacket.class, i++, Side.CLIENT);		//Legacy turret yaw/pitch sync (CIWS, etc.)
 		wrapper.registerMessage(AuxGaugePacket.Handler.class, AuxGaugePacket.class, i++, Side.CLIENT);	//The horrid one
 		wrapper.registerMessage(NBTPacket.Handler.class, NBTPacket.class, i++, Side.CLIENT);			//The convenient but laggy one
 		wrapper.registerMessage(BufPacket.Handler.class, BufPacket.class, i++, Side.CLIENT);			//The not-so-convenient but not laggy one

--- a/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
+++ b/src/main/java/com/hbm/tileentity/bomb/TileEntityTurretBase.java
@@ -9,6 +9,7 @@ import com.hbm.lib.Library;
 import com.hbm.packet.PacketDispatcher;
 import com.hbm.packet.TETurretPacket;
 
+import cpw.mods.fml.common.network.NetworkRegistry.TargetPoint;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.Entity;
@@ -44,6 +45,7 @@ public abstract class TileEntityTurretBase extends TileEntity {
 		//TODOne if you do not power turret, it will not shoot and rotate.
 
 		if(isAI && canOperate()) {
+
 			//we only care about the AI part of our automated close in weapon system.
 
 
@@ -93,6 +95,12 @@ public abstract class TileEntityTurretBase extends TileEntity {
 
 			} else {
 				use = 0;
+			}
+			if(!worldObj.isRemote && (rotationYaw != lastYaw || rotationPitch != lastPitch)) {
+				PacketDispatcher.wrapper.sendToAllAround(new TETurretPacket(xCoord, yCoord, zCoord, rotationYaw, rotationPitch),
+					new TargetPoint(worldObj.provider.dimensionId, xCoord + 0.5, yCoord + 0.5, zCoord + 0.5, 128));
+				lastYaw = rotationYaw;
+				lastPitch = rotationPitch;
 			}
 		}
 	}


### PR DESCRIPTION
### Motivation

- Ensure turret yaw/pitch are propagated from server to nearby clients so client-side rendering/animations (CIWS and other turrets) stay in sync.

### Description

- Register the `TETurretPacket` handler on the client in `PacketDispatcher` so the client can receive turret orientation updates.
- Send `TETurretPacket` from `TileEntityTurretBase` when `rotationYaw` or `rotationPitch` change on the server using `PacketDispatcher.wrapper.sendToAllAround` and `TargetPoint` with a 128-block radius.
- Update `TileEntityTurretBase` to import `TargetPoint` and to track and update `lastYaw`/`lastPitch` after sending packets.

### Testing

- Built the project with `./gradlew build` and the build completed successfully.
- Executed `./gradlew test` and no failing tests were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a151e435aa48323b566f1c7e88d44fa)