### PR TITLE
Fix CIWS server-side crash caused by removed World API

### DIFF
--- a/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
+++ b/src/main/java/com/hbm/blocks/bomb/TurretCIWS.java
@@ -88,9 +88,6 @@ public class TurretCIWS extends TurretBase implements ITooltipProvider {
 	}
 
 	private void rayShot(World world, Vec3 vec, double posX, double posY, double posZ, int range, float damage, int hitPercent) {
-		List<Entity> entities = world.getLoadedEntityList();
-
-
 		for(float i = 0; i < range; i += 0.25F) {
 			double pX = posX + vec.xCoord * i;
 			double pY = posY + vec.yCoord * i;


### PR DESCRIPTION
### Motivation
- The server experienced a `NoSuchMethodError` during block entity ticking because code called the removed `World#getLoadedEntityList()` from the CIWS turret.

### Description
- Remove the unused `List<Entity> entities = world.getLoadedEntityList();` line from `src/main/java/com/hbm/blocks/bomb/TurretCIWS.java` so the raycast/hit logic relies solely on `getEntitiesWithinAABBExcludingEntity`.

### Testing
- Ran `rg -n "getLoadedEntityList(" src/main/java` (no matches) and committed the change with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15241398e0832390a4689eb22f7380)