### PR TITLE
Improve celestial time sync and orbital realism

### DIFF
--- a/src/main/java/com/hbm/dim/CelestialBody.java
+++ b/src/main/java/com/hbm/dim/CelestialBody.java
@@ -46,6 +46,7 @@ public class CelestialBody {
 	public float massKg = 0;
 	public float radiusKm = 0;
 	public double semiMajorAxisKm = 0; // Distance to the parent body
+	public double initialOrbitalAngle = 0; // Mean longitude offset in degrees
 	private int rotationalPeriod = 6 * 60 * 60; // Day length in seconds
 
 	public float axialTilt = 0;
@@ -123,6 +124,11 @@ public class CelestialBody {
 
 	public CelestialBody withRotationalPeriod(int seconds) {
 		this.rotationalPeriod = seconds;
+		return this;
+	}
+
+	public CelestialBody withInitialOrbitalAngle(double degrees) {
+		this.initialOrbitalAngle = degrees;
 		return this;
 	}
 
@@ -496,9 +502,15 @@ public class CelestialBody {
 		return body;
 	}
 
-	// Returns the day length in ticks, adjusted for the 20 minute minecraft day
+	// Returns the day length in ticks, adjusted for the configured Minecraft time compression.
+	// The magnitude is always positive; use getRotationDirection() to preserve
+	// retrograde bodies such as Venus, Uranus and Pluto.
 	public double getRotationalPeriod() {
-		return rotationalPeriod * 20.0 * TIME_SCALE;
+		return Math.abs(rotationalPeriod) * 20.0 * TIME_SCALE;
+	}
+
+	public int getRotationDirection() {
+		return rotationalPeriod < 0 ? -1 : 1;
 	}
 
 	public static final double ORBIT_TIME_SCALE = 1.0 / 100000.0;

--- a/src/main/java/com/hbm/dim/SolarSystem.java
+++ b/src/main/java/com/hbm/dim/SolarSystem.java
@@ -66,6 +66,7 @@ public class SolarSystem {
 				new CelestialBody("moho", SpaceConfig.mohoDimension, Body.MOHO)
 					.withMassRadius(3.301e23F, 2_440)
 					.withSemiMajorAxis(57_909_050D)
+					.withInitialOrbitalAngle(252.25D)
 					.withRotationalPeriod(5_067_072) // 58.646 Earth days
 					.withColor(0.4863F, 0.4F, 0.3456F)
 					.withBlockTextures(RefStrings.MODID + ":textures/blocks/moho_stone.png", RefStrings.MODID + ":textures/blocks/moho_regolith.png")
@@ -77,6 +78,7 @@ public class SolarSystem {
 				new CelestialBody("eve", SpaceConfig.eveDimension, Body.EVE)
 					.withMassRadius(4.867e24F, 6_052)
 					.withSemiMajorAxis(108_208_000D)
+					.withInitialOrbitalAngle(181.98D)
 					.withRotationalPeriod(-20_996_640) // -243.025 Earth days
 					.withColor(0.408F, 0.298F, 0.553F)
 					.withBlockTextures(RefStrings.MODID + ":textures/blocks/eve_stone_2.png", RefStrings.MODID + ":textures/blocks/eve_silt.png")
@@ -102,6 +104,7 @@ public class SolarSystem {
 				new CelestialBody("kerbin", 0, Body.KERBIN) // overworld
 					.withMassRadius(5.972e24F, 6_371)
 					.withSemiMajorAxis(149_598_023D)
+					.withInitialOrbitalAngle(100.46D)
 					.withRotationalPeriod(86_164) // sidereal day
 					.withAxialTilt(23.44F)
 					.withBlockTextures("textures/blocks/stone.png", "textures/blocks/dirt.png")
@@ -148,6 +151,7 @@ public class SolarSystem {
 				new CelestialBody("duna", SpaceConfig.dunaDimension, Body.DUNA)
 					.withMassRadius(6.417e23F, 3_390)
 					.withSemiMajorAxis(227_943_824D)
+					.withInitialOrbitalAngle(355.43D)
 					.withRotationalPeriod(88_775) // 24h 37m 22s
 					.withAxialTilt(25.19F)
 					//.withTidalLockingTo("ike") //??? literally fucking what
@@ -199,6 +203,7 @@ public class SolarSystem {
 				new CelestialBody("dres", SpaceConfig.dresDimension, Body.DRES)
 					.withMassRadius(9.393e20F, 469)
 					.withSemiMajorAxis(413_700_000D)
+					.withInitialOrbitalAngle(80.30D)
 					.withRotationalPeriod(32_673)
 					.withBlockTextures(RefStrings.MODID + ":textures/blocks/dresbase.png", RefStrings.MODID + ":textures/blocks/sellafield_slaked.png")
 					.withTraits(new CBT_Temperature(-105))
@@ -215,6 +220,7 @@ public class SolarSystem {
 
 					//skibidi mode: on
 					.withSemiMajorAxis(778_547_200D)
+					.withInitialOrbitalAngle(34.35D)
 					.withRotationalPeriod(35_730) // System III rotation
 					//.withColor(0.4588f, 0.6784f, 0.3059f)
 					//was neptune/uranus color?
@@ -283,6 +289,7 @@ public class SolarSystem {
 				new CelestialBody("sarnus")
 					.withMassRadius(5.683e26F, 58_232)
 					.withSemiMajorAxis(1_433_530_000D)
+					.withInitialOrbitalAngle(50.08D)
 					.withRotationalPeriod(38_362)
 					.withColor(1f, 0.6862f, 0.5882f)
 					.withAxialTilt(26.73F)
@@ -344,6 +351,7 @@ public class SolarSystem {
 				new CelestialBody("uranus")
 					.withMassRadius(8.681e25F, 25_362)
 					.withSemiMajorAxis(2_872_463_000D)
+					.withInitialOrbitalAngle(314.06D)
 					.withRotationalPeriod(-62_064)
 					.withColor(0.4F, 0.6F, 0.8F)
 					.withAxialTilt(97.77F)
@@ -388,6 +396,7 @@ public class SolarSystem {
 				new CelestialBody("neptune")
 					.withMassRadius(1.024e26F, 24_622)
 					.withSemiMajorAxis(4_495_060_000D)
+					.withInitialOrbitalAngle(304.35D)
 					.withRotationalPeriod(57_996)
 					.withColor(0.2F, 0.4F, 0.6F)
 					.withAxialTilt(28.32F)
@@ -429,6 +438,7 @@ public class SolarSystem {
 					// but god only knows how many fucking times in this code it's referenced
 					.withMassRadius(1.309e22F, 1_188)
 					.withSemiMajorAxis(5_906_380_000D)
+					.withInitialOrbitalAngle(238.93D)
 					.withRotationalPeriod(-551_857) // retrograde
 					.withAxialTilt(122.53F)
 					.withTraits(new CBT_Temperature(-229))
@@ -649,7 +659,7 @@ public class SolarSystem {
 	private static Vec3 calculatePosition(CelestialBody body, double ticks) {
 		// Get how far (in radians) a planet has gone around its parent
 		double yearTicks = body.getOrbitalPeriod() * (double)AstronomyUtil.TICKS_IN_DAY;
-		double angleRadians = 2 * Math.PI * (ticks / yearTicks);
+		double angleRadians = 2 * Math.PI * (ticks / yearTicks) + Math.toRadians(body.initialOrbitalAngle);
 
 		double x = body.semiMajorAxisKm * Math.cos(angleRadians);
 		double y = body.semiMajorAxisKm * Math.sin(angleRadians);

--- a/src/main/java/com/hbm/dim/WorldProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/WorldProviderCelestial.java
@@ -31,6 +31,7 @@ import net.minecraftforge.client.IRenderHandler;
 public abstract class WorldProviderCelestial extends WorldProvider {
 
 	private long localTime = -1;
+	private long clientLocalTimeSyncTick = -1;
 
 	@Override
 	public abstract void registerWorldChunkManager();
@@ -121,9 +122,17 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 	public void deserialize(ByteBuf buf) {
 		long time = buf.readLong();
 
-		// Allow a half second desync for smoothness
-		if(Math.abs(time - getWorldTime()) > 10) {
-			setWorldTime(time);
+		// The packet carries the planet's raw local tick counter, not the
+		// 0-24000 vanilla day value returned by getWorldTime(). Comparing
+		// against getWorldTime() made clients reject almost every sync once a
+		// planet's local clock exceeded a single vanilla day, leaving non-Earth
+		// skies apparently frozen between occasional full resyncs.
+		if(Math.abs(time - getLocalTime()) > 10) {
+			localTime = time;
+		}
+
+		if(worldObj != null) {
+			clientLocalTimeSyncTick = worldObj.getTotalWorldTime();
 		}
 	}
 
@@ -430,11 +439,8 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 		if(dimensionId == 0) return;
 		if(!worldObj.getGameRules().getGameRuleBooleanValue("doDaylightCycle")) return;
 
-		long dayLength = (long)getDayLength();
 		long current = getWorldTime();
-
-		long nextMorning =
-			(current / dayLength + 1) * dayLength;
+		long nextMorning = (current / 24000L + 1L) * 24000L;
 
 		setWorldTime(nextMorning);
 	}
@@ -446,24 +452,40 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 			return super.getWorldTime();
 		}
 
-		if(!worldObj.isRemote) {
-			localTime =
-				CelestialBodyWorldSavedData
-					.get(this)
-					.getLocalTime();
-		}
-
+		long time = getLocalTime();
 		double dayLength = getDayLength();
+		double normalized = normalizeDayTime(time, dayLength);
 
-		double normalized =
-			(localTime % dayLength)
-				/ dayLength;
+		if(CelestialBody.getBody(worldObj).getRotationDirection() < 0) {
+			normalized = normalizeDayTime(-time, dayLength);
+		}
 
 		return (long)(normalized * 24000L);
 	}
 
 	public long getLocalTime() {
-		return localTime;
+		if(dimensionId == 0) {
+			return super.getWorldTime();
+		}
+
+		if(worldObj == null) {
+			return localTime;
+		}
+
+		if(!worldObj.isRemote) {
+			localTime = CelestialBodyWorldSavedData.get(this).getLocalTime();
+			return localTime;
+		}
+
+		if(localTime < 0 || clientLocalTimeSyncTick < 0) {
+			return worldObj.getWorldTime();
+		}
+
+		if(!worldObj.getGameRules().getGameRuleBooleanValue("doDaylightCycle")) {
+			return localTime;
+		}
+
+		return localTime + worldObj.getTotalWorldTime() - clientLocalTimeSyncTick;
 	}
 
 	@Override
@@ -475,9 +497,13 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 		}
 
 		double dayLength = getDayLength();
+		double normalized = time / 24000.0D;
 
-		long local =
-			(long)((time / 24000.0D) * dayLength);
+		if(CelestialBody.getBody(worldObj).getRotationDirection() < 0) {
+			normalized = -normalized;
+		}
+
+		long local = (long)(normalized * dayLength);
 
 		if(!worldObj.isRemote) {
 			CelestialBodyWorldSavedData.get(this)
@@ -485,6 +511,9 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 		}
 
 		localTime = local;
+		if(worldObj != null && worldObj.isRemote) {
+			clientLocalTimeSyncTick = worldObj.getTotalWorldTime();
+		}
 	}
 
 	@Override
@@ -529,16 +558,41 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 	//	return body.getRotationalPeriod() / (1 - (1 / body.getPlanet().getOrbitalPeriod()));
 	//}
 	protected double getDayLength() {
-		return CelestialBody.getBody(worldObj).getRotationalPeriod();
+		CelestialBody body = CelestialBody.getBody(worldObj);
+		double siderealDay = body.getRotationalPeriod();
+		double year = getSolarYearLength(body);
+
+		if(Double.isInfinite(year) || year <= 0.0D) {
+			return Math.max(1.0D, siderealDay);
+		}
+
+		// Convert sidereal rotation into the local solar day. This is what the
+		// sky renderer needs: noon-to-noon, not fixed-star rotation. It makes
+		// Mercury's long day and Venus' retrograde day behave much closer to
+		// reality while preserving the existing compressed time scale.
+		double solarFrequency = (body.getRotationDirection() / siderealDay) - (1.0D / year);
+		if(Math.abs(solarFrequency) < 1.0E-9D) {
+			return siderealDay;
+		}
+
+		return Math.max(1.0D, Math.abs(1.0D / solarFrequency));
+	}
+
+	private double getSolarYearLength(CelestialBody body) {
+		CelestialBody orbiting = body.parent != null && body.parent.parent != null ? body.parent : body;
+		double orbitalPeriod = orbiting.getOrbitalPeriod();
+
+		if(Double.isInfinite(orbitalPeriod)) {
+			return Double.POSITIVE_INFINITY;
+		}
+
+		return orbitalPeriod * 20.0D * CelestialBody.TIME_SCALE;
 	}
 
 	public float getNormalizedDayTime() {
 		double dayLength = getDayLength();
 
-		return (float)(
-			(getLocalTime() % dayLength)
-				/ dayLength
-		);
+		return (float)normalizeDayTime(getLocalTime(), dayLength);
 	}
 
 	@Override
@@ -546,12 +600,11 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 
 		double dayLength = getDayLength();
 
-		//TODO possibly blame
-		double j =
+		double localTicks =
 			(worldTime / 24000.0D) * dayLength;
 
 		double f1 =
-			(j + partialTicks)
+			(localTicks + partialTicks)
 				/ dayLength
 				- 0.25F;
 
@@ -576,6 +629,12 @@ public abstract class WorldProviderCelestial extends WorldProvider {
 				(f1 - f2)
 					/ 3.0D
 		);
+	}
+
+	private double normalizeDayTime(double time, double dayLength) {
+		double normalized = time % dayLength;
+		if(normalized < 0.0D) normalized += dayLength;
+		return normalized / dayLength;
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation
- Fix non-Earth skies that remained static by making planetary time sync compare and interpolate the planet-local tick counter instead of vanilla `0-24000` world time.  
- Make the rendered solar system appear less artificially aligned and more realistic by adding orbital phase offsets and handling retrograde/solar day differences.

### Description
- Use absolute rotational period magnitude and expose rotation direction with `getRotationDirection()` in `CelestialBody` to preserve retrograde bodies while keeping day-length math positive (`src/main/java/com/hbm/dim/CelestialBody.java`).
- Add `initialOrbitalAngle` and `withInitialOrbitalAngle(...)` to `CelestialBody` and apply per-body offsets in `SolarSystem.calculatePosition(...)` so planets do not all start aligned (`src/main/java/com/hbm/dim/SolarSystem.java`, `src/main/java/com/hbm/dim/CelestialBody.java`).
- Replace client-side time comparison in `WorldProviderCelestial.deserialize(...)` to compare the raw planetary local tick counter and record a client sync tick, enabling interpolation instead of immediate rejection of non-vanilla-time values (`src/main/java/com/hbm/dim/WorldProviderCelestial.java`).
- Implement client-side local-time extrapolation: `getLocalTime()` now returns the last synced local tick plus `world.getTotalWorldTime() - clientLocalTimeSyncTick` when possible so non-Earth skies progress smoothly between full syncs (`src/main/java/com/hbm/dim/WorldProviderCelestial.java`).
- Convert sidereal rotation into an apparent solar day in `getDayLength()` by combining body rotation and orbital period so sunrise/sunset timing aligns with solar day expectations (handles retrograde rotation correctly) (`src/main/java/com/hbm/dim/WorldProviderCelestial.java`).
- Add helper `normalizeDayTime(...)` and adjust `calculateCelestialAngle(...)`, `getWorldTime()`, and `setWorldTime(...)` to use planetary-local time, normalization and rotation direction where needed (`src/main/java/com/hbm/dim/WorldProviderCelestial.java`, `src/main/java/com/hbm/dim/CelestialBody.java`).

### Testing
- Ran `git diff --check` to ensure no whitespace/merge errors and it completed without issues (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18b598c4308323bb6a2238147391ea)