### PR TITLE
Add Neptune dimension and atmosphere (realistic Neptune)

### DIFF
--- a/src/main/java/com/hbm/blocks/ModBlocks.java
+++ b/src/main/java/com/hbm/blocks/ModBlocks.java
@@ -1340,6 +1340,13 @@ public class ModBlocks {
 	public static Block uranus_cloud_dense;
 	public static Block uranus_atmosphere;
 
+	//NEPTUNE
+	public static Block neptune_cloud_thin;
+	public static Block neptune_cloud;
+	public static Block neptune_cloud_dense;
+	public static Block neptune_atmosphere_dense;
+	public static Block neptune_storm;
+
 
 
 	public static Block rad_lava_block;
@@ -2644,6 +2651,17 @@ public class ModBlocks {
 		uranus_atmosphere =
 			new BlockUranusAtmosphere();
 
+		neptune_cloud_thin =
+			new BlockNeptuneCloudThin();
+		neptune_cloud =
+			new BlockNeptuneCloud();
+		neptune_cloud_dense =
+			new BlockNeptuneCloudDense();
+		neptune_atmosphere_dense =
+			new BlockNeptuneAtmosphereDense();
+		neptune_storm =
+			new BlockNeptuneStorm();
+
 
 		rad_lava_fluid = new RadFluid().setLuminosity(15).setDensity(3000).setViscosity(3000).setTemperature(1300).setUnlocalizedName("rad_lava_fluid");
 		FluidRegistry.registerFluid(rad_lava_fluid);
@@ -3936,6 +3954,28 @@ public class ModBlocks {
 		GameRegistry.registerBlock(
 			uranus_atmosphere,
 			"uranus_atmosphere"
+		);
+
+		//NEPTUNE
+		GameRegistry.registerBlock(
+			neptune_cloud_thin,
+			"neptune_cloud_thin"
+		);
+		GameRegistry.registerBlock(
+			neptune_cloud,
+			"neptune_cloud"
+		);
+		GameRegistry.registerBlock(
+			neptune_cloud_dense,
+			"neptune_cloud_dense"
+		);
+		GameRegistry.registerBlock(
+			neptune_atmosphere_dense,
+			"neptune_atmosphere_dense"
+		);
+		GameRegistry.registerBlock(
+			neptune_storm,
+			"neptune_storm"
 		);
 
 		GameRegistry.registerBlock(corium_block, corium_block.getUnlocalizedName());

--- a/src/main/java/com/hbm/blocks/gas/BlockNeptuneAtmosphereDense.java
+++ b/src/main/java/com/hbm/blocks/gas/BlockNeptuneAtmosphereDense.java
@@ -1,0 +1,52 @@
+package com.hbm.blocks.gas;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockNeptuneAtmosphereDense extends BlockGasBase {
+
+	public BlockNeptuneAtmosphereDense() {
+		super(0.015F, 0.045F, 0.16F);
+		this.setBlockName("neptune_atmosphere_dense");
+		this.setBlockTextureName("hbm:neptune_atmosphere_dense");
+		this.setLightOpacity(6);
+	}
+
+	@Override
+	public boolean isStaticGas() {
+		return true;
+	}
+
+	@Override
+	public ForgeDirection getFirstDirection(World world, int x, int y, int z) {
+		return ForgeDirection.DOWN;
+	}
+
+	@Override
+	public ForgeDirection getSecondDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public int getDelay(World world) {
+		return 2;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+		entity.motionX *= 0.82D;
+		entity.motionY *= 0.82D;
+		entity.motionZ *= 0.82D;
+
+		entity.motionX += Math.sin(z * 0.002D) * 0.20D;
+		entity.motionY -= 0.02D;
+		entity.fallDistance = 0F;
+
+		if(entity instanceof EntityLivingBase && world.rand.nextInt(100) == 0) {
+			((EntityLivingBase)entity).attackEntityFrom(DamageSource.drown, 1.0F);
+		}
+	}
+}

--- a/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloud.java
+++ b/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloud.java
@@ -1,0 +1,50 @@
+package com.hbm.blocks.gas;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockNeptuneCloud extends BlockGasBase {
+
+	public BlockNeptuneCloud() {
+		super(0.08F, 0.19F, 0.62F);
+		this.setBlockName("neptune_cloud");
+		this.setBlockTextureName("hbm:neptune_cloud");
+		this.setLightOpacity(1);
+	}
+
+	@Override
+	public boolean isStaticGas() {
+		return true;
+	}
+
+	@Override
+	public ForgeDirection getFirstDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public ForgeDirection getSecondDirection(World world, int x, int y, int z) {
+		if(world.rand.nextInt(10) == 0)
+			return world.rand.nextBoolean() ? ForgeDirection.UP : ForgeDirection.DOWN;
+
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public int getDelay(World world) {
+		return 2;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+		entity.motionX *= 0.96D;
+		entity.motionY *= 0.99D;
+		entity.motionZ *= 0.96D;
+
+		double jet = Math.sin(z * 0.004D) * 0.18D;
+		entity.motionX += jet;
+		entity.motionZ += (world.rand.nextDouble() - 0.5D) * 0.04D;
+		entity.fallDistance = 0F;
+	}
+}

--- a/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloudDense.java
+++ b/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloudDense.java
@@ -1,0 +1,50 @@
+package com.hbm.blocks.gas;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockNeptuneCloudDense extends BlockGasBase {
+
+	public BlockNeptuneCloudDense() {
+		super(0.04F, 0.12F, 0.40F);
+		this.setBlockName("neptune_cloud_dense");
+		this.setBlockTextureName("hbm:neptune_cloud_dense");
+		this.setLightOpacity(3);
+	}
+
+	@Override
+	public boolean isStaticGas() {
+		return true;
+	}
+
+	@Override
+	public ForgeDirection getFirstDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public ForgeDirection getSecondDirection(World world, int x, int y, int z) {
+		return world.rand.nextInt(8) == 0
+			? ForgeDirection.DOWN
+			: randomHorizontal(world);
+	}
+
+	@Override
+	public int getDelay(World world) {
+		return 2;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+		entity.motionX *= 0.91D;
+		entity.motionY *= 0.96D;
+		entity.motionZ *= 0.91D;
+
+		double jet = Math.sin(z * 0.003D + y * 0.02D) * 0.28D;
+		entity.motionX += jet;
+		entity.motionZ += (world.rand.nextDouble() - 0.5D) * 0.10D;
+		entity.motionY -= 0.006D;
+		entity.fallDistance = 0F;
+	}
+}

--- a/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloudThin.java
+++ b/src/main/java/com/hbm/blocks/gas/BlockNeptuneCloudThin.java
@@ -1,0 +1,44 @@
+package com.hbm.blocks.gas;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockNeptuneCloudThin extends BlockGasBase {
+
+	public BlockNeptuneCloudThin() {
+		super(0.10F, 0.22F, 0.70F);
+		this.setBlockName("neptune_cloud_thin");
+		this.setBlockTextureName("hbm:neptune_cloud_thin");
+	}
+
+	@Override
+	public boolean isStaticGas() {
+		return true;
+	}
+
+	@Override
+	public ForgeDirection getFirstDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public ForgeDirection getSecondDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public int getDelay(World world) {
+		return 3;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+		entity.motionX *= 0.985D;
+		entity.motionZ *= 0.985D;
+
+		double wind = Math.sin(z * 0.006D + y * 0.03D) * 0.08D;
+		entity.motionX += wind;
+		entity.fallDistance = 0F;
+	}
+}

--- a/src/main/java/com/hbm/blocks/gas/BlockNeptuneStorm.java
+++ b/src/main/java/com/hbm/blocks/gas/BlockNeptuneStorm.java
@@ -1,0 +1,79 @@
+package com.hbm.blocks.gas;
+
+import java.util.Random;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class BlockNeptuneStorm extends BlockGasBase {
+
+	public BlockNeptuneStorm() {
+		super(0.02F, 0.08F, 0.34F);
+		this.setBlockName("neptune_storm");
+		this.setBlockTextureName("hbm:neptune_storm");
+		this.setLightOpacity(4);
+	}
+
+	@Override
+	public boolean isStaticGas() {
+		return true;
+	}
+
+	@Override
+	public ForgeDirection getFirstDirection(World world, int x, int y, int z) {
+		return randomHorizontal(world);
+	}
+
+	@Override
+	public ForgeDirection getSecondDirection(World world, int x, int y, int z) {
+		return ForgeDirection.getOrientation(world.rand.nextInt(6));
+	}
+
+	@Override
+	public int getDelay(World world) {
+		return 1;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity) {
+		entity.motionX *= 0.88D;
+		entity.motionY *= 0.93D;
+		entity.motionZ *= 0.88D;
+
+		double angle = x * 0.012D + z * 0.017D;
+		entity.motionX += Math.cos(angle) * 0.45D + (world.rand.nextDouble() - 0.5D) * 0.35D;
+		entity.motionZ += Math.sin(angle) * 0.45D + (world.rand.nextDouble() - 0.5D) * 0.35D;
+		entity.motionY += (world.rand.nextDouble() - 0.45D) * 0.16D;
+		entity.fallDistance = 0F;
+
+		if(entity instanceof EntityLivingBase && world.rand.nextInt(60) == 0) {
+			((EntityLivingBase)entity).attackEntityFrom(DamageSource.magic, 1.0F);
+		}
+	}
+
+	@Override
+	public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
+		super.randomDisplayTick(world, x, y, z, rand);
+
+		EntityPlayer player = world.getClosestPlayer(x + 0.5D, y + 0.5D, z + 0.5D, 18.0D);
+
+		if(player == null)
+			return;
+
+		if(rand.nextInt(80) == 0) {
+			world.spawnParticle(
+				"reddust",
+				x + rand.nextDouble(),
+				y + rand.nextDouble(),
+				z + rand.nextDouble(),
+				0.0D,
+				0.0D,
+				1.0D
+			);
+		}
+	}
+}

--- a/src/main/java/com/hbm/config/SpaceConfig.java
+++ b/src/main/java/com/hbm/config/SpaceConfig.java
@@ -32,6 +32,7 @@ public class SpaceConfig {
 	public static int sunDimension = 103;
 	public static int saturnDimension = 102;
 	public static int uranusDimension = 107;
+	public static int neptuneDimension = 108;
 
 
 	//BIOME:
@@ -122,6 +123,13 @@ public class SpaceConfig {
 			"Uranus dimension ID",
 			uranusDimension
 		);
+		neptuneDimension = CommonConfig.createConfigInt(
+			config,
+			CATEGORY_DIM,
+			"17.15_neptuneDimension",
+			"Neptune dimension ID",
+			neptuneDimension
+		);
 
 		final String CATEGORY_GENERAL = CommonConfig.CATEGORY_GENERAL;
 		maxProbeDistance = CommonConfig.createConfigInt(config, CATEGORY_GENERAL, "1.90_maxProbeDistance", "How far from the center of the dimension can probes generate landing coordinates", maxProbeDistance);
@@ -170,6 +178,20 @@ public class SpaceConfig {
 			"16.27_saturnBiome",
 			"Saturn Biome ID",
 			saturnBiome
+		);
+		uranusBiome = CommonConfig.createConfigInt(
+			config,
+			CATEGORY_BIOME,
+			"16.28_uranusBiome",
+			"Uranus Biome ID",
+			uranusBiome
+		);
+		neptuneBiome = CommonConfig.createConfigInt(
+			config,
+			CATEGORY_BIOME,
+			"16.29_neptuneBiome",
+			"Neptune Biome ID",
+			neptuneBiome
 		);
 		//laytheFractureBiome = CommonConfig.createConfigInt(
 		//	config,
@@ -257,6 +279,12 @@ public class SpaceConfig {
 		uranusDimension =
 			findFreeDimensionId(
 				uranusDimension,
+				used
+			);
+
+		neptuneDimension =
+			findFreeDimensionId(
+				neptuneDimension,
 				used
 			);
 

--- a/src/main/java/com/hbm/dim/SolarSystem.java
+++ b/src/main/java/com/hbm/dim/SolarSystem.java
@@ -370,7 +370,7 @@ public class SolarSystem {
 					),
 
 				//neptune
-				new CelestialBody("neptune")
+				new CelestialBody("neptune", SpaceConfig.neptuneDimension, Body.NEPTUNE)
 					.withMassRadius(1.024e26F, 24_622)
 					.withSemiMajorAxis(4_495_060_000D)
 					.withInitialOrbitalAngle(304.35D)
@@ -379,7 +379,8 @@ public class SolarSystem {
 					.withAxialTilt(28.32F)
 					.withTraits(
 						new CBT_Atmosphere(Fluids.HYDROGEN, 100D)
-							.and(Fluids.GAS, 10D),
+							.and(Fluids.HELIUM4, 18D)
+							.and(Fluids.NGAS, 3D),
 						new CBT_Temperature(-214)
 					)
 					.withSatellites(
@@ -450,7 +451,8 @@ public class SolarSystem {
 		SUN("kerbol"), //God I really need to change this to real names
 		JOOL("jool"), //pain
 		SARNUS("sarnus"),
-		URANUS("uranus");
+		URANUS("uranus"),
+		NEPTUNE("neptune");
 		// TEKTO("tekto");
 
 		public String name;

--- a/src/main/java/com/hbm/dim/neptune/WorldProviderNeptune.java
+++ b/src/main/java/com/hbm/dim/neptune/WorldProviderNeptune.java
@@ -2,12 +2,17 @@ package com.hbm.dim.neptune;
 
 import com.hbm.dim.WorldChunkManagerCelestial;
 import com.hbm.dim.WorldProviderCelestial;
-import com.hbm.dim.saturn.ChunkProviderSaturn;
+import com.hbm.dim.neptune.GenLayerNeptune.GenLayerNeptuneBiomes;
+import com.hbm.potion.HbmPotion;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.layer.GenLayer;
+import net.minecraft.world.gen.layer.GenLayerVoronoiZoom;
 
 public class WorldProviderNeptune extends WorldProviderCelestial {
 
@@ -19,24 +24,103 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 				createNeptune(worldObj.getSeed())
 			);
 	}
+
 	@Override
 	public String getDimensionName() {
 		return "Neptune";
 	}
+
 	@Override
 	public IChunkProvider createChunkGenerator() {
-		return new ChunkProviderNeptune(this.worldObj, this.getSeed(), false);
+		return new ChunkProviderNeptune(
+			this.worldObj,
+			this.getSeed(),
+			false
+		);
 	}
 
 	@Override
 	public void updateWeather() {
 
-		worldObj.getWorldInfo().setRaining(true);
-		worldObj.getWorldInfo().setThundering(true);
+		// Neptune has no surface rain, but it does have persistent deep storms.
+		this.worldObj.rainingStrength = 0.0F;
+		this.worldObj.thunderingStrength = 0.7F;
+
+		this.worldObj
+			.getWorldInfo()
+			.setRaining(false);
+
+		this.worldObj
+			.getWorldInfo()
+			.setThundering(true);
+
+		if(worldObj.isRemote)
+			return;
+
+		for(Object obj :
+			worldObj.playerEntities) {
+
+			if(!(obj instanceof EntityPlayer))
+				continue;
+
+			EntityPlayer player =
+				(EntityPlayer)obj;
+
+			int amp;
+
+			// exposed upper methane haze
+			if(player.posY > 220) {
+
+				amp = 12;
+			}
+
+			// cold cloud tops and charged storm bands
+			else if(player.posY > 170) {
+
+				amp = 6;
+			}
+
+			// deeper atmosphere provides more shielding
+			else if(player.posY > 100) {
+
+				amp = 2;
+			}
+
+			else {
+
+				amp = 0;
+			}
+
+			if(amp > 0) {
+
+				player.addPotionEffect(
+					new PotionEffect(
+						HbmPotion.radiation.id,
+						20,
+						amp
+					)
+				);
+			}
+		}
 	}
 
 	private static WorldChunkManagerCelestial.BiomeGenLayers createNeptune(long seed) {
-		//TODO
+
+		// One planet-wide cold methane/hydrogen atmosphere biome.
+		GenLayer genlayerBiomes =
+			new GenLayerNeptuneBiomes(seed);
+
+		GenLayerVoronoiZoom genlayerVoronoi =
+			new GenLayerVoronoiZoom(
+				10L,
+				genlayerBiomes
+			);
+
+		return new WorldChunkManagerCelestial.BiomeGenLayers(
+			genlayerBiomes,
+			genlayerVoronoi,
+			seed
+		);
 	}
 
 	@Override
@@ -44,9 +128,9 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 	public Vec3 getSkyColor(Entity camera, float partialTicks) {
 
 		return Vec3.createVectorHelper(
-			0.08,
-			0.20,
-			0.45
+			0.06,
+			0.18,
+			0.48
 		);
 	}
 
@@ -55,9 +139,9 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 	public Vec3 getFogColor(float celestialAngle, float partialTicks) {
 
 		return Vec3.createVectorHelper(
-			0.03,
-			0.09,
-			0.20
+			0.02,
+			0.07,
+			0.18
 		);
 	}
 
@@ -65,13 +149,16 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 	@SideOnly(Side.CLIENT)
 	public float getSunBrightness(float partialTicks) {
 
-		return 0.06F;
+		// About thirty astronomical units from the Sun.
+		return 0.012F;
 	}
 
 	@Override
 	public float calculateCelestialAngle(long worldTime, float partialTicks) {
 
-		int dayLength = 16000;
+		// Neptune rotates in about 16.1 Earth hours.
+		long dayLength =
+			19360L;
 
 		long time =
 			worldTime % dayLength;
@@ -79,7 +166,6 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 		return ((float)time + partialTicks)
 			/ (float)dayLength - 0.25F;
 	}
-
 
 	@Override
 	public boolean isSurfaceWorld() {
@@ -95,9 +181,4 @@ public class WorldProviderNeptune extends WorldProviderCelestial {
 	public boolean canCoordinateBeSpawn(int x, int z) {
 		return false;
 	}
-
-
-
-
-
 }

--- a/src/main/java/com/hbm/dim/neptune/biome/BiomeGenBaseNeptune.java
+++ b/src/main/java/com/hbm/dim/neptune/biome/BiomeGenBaseNeptune.java
@@ -2,12 +2,11 @@ package com.hbm.dim.neptune.biome;
 
 import com.hbm.config.SpaceConfig;
 import com.hbm.dim.BiomeGenBaseCelestial;
-import com.hbm.dim.saturn.biome.BiomeGenSaturn;
 
 public class BiomeGenBaseNeptune {
+
 	public static final BiomeGenBaseCelestial neptune =
 		(BiomeGenBaseCelestial)new BiomeGenNeptune(
 			SpaceConfig.neptuneBiome
 		).setBiomeName("Neptune");
-
 }

--- a/src/main/java/com/hbm/dim/neptune/biome/BiomeGenNeptune.java
+++ b/src/main/java/com/hbm/dim/neptune/biome/BiomeGenNeptune.java
@@ -1,12 +1,14 @@
 package com.hbm.dim.neptune.biome;
 
 import com.hbm.dim.BiomeGenBaseCelestial;
+import net.minecraft.world.World;
+
+import java.util.Random;
 
 public class BiomeGenNeptune extends BiomeGenBaseCelestial {
 
 	public BiomeGenNeptune(int id) {
 		super(id);
-		//TODO check if right
 
 		this.rootHeight = 8.0F;
 		this.heightVariation = 0.0F;
@@ -16,6 +18,7 @@ public class BiomeGenNeptune extends BiomeGenBaseCelestial {
 
 		this.enableRain = false;
 
+		theBiomeDecorator.generateLakes = false;
 		this.theBiomeDecorator.treesPerChunk = 0;
 		this.theBiomeDecorator.flowersPerChunk = 0;
 		this.theBiomeDecorator.grassPerChunk = 0;
@@ -26,6 +29,7 @@ public class BiomeGenNeptune extends BiomeGenBaseCelestial {
 		this.theBiomeDecorator.sandPerChunk = 0;
 		this.theBiomeDecorator.sandPerChunk2 = 0;
 		this.theBiomeDecorator.clayPerChunk = 0;
+		this.theBiomeDecorator.bigMushroomsPerChunk = 0;
 
 		this.spawnableCreatureList.clear();
 		this.spawnableMonsterList.clear();
@@ -33,4 +37,13 @@ public class BiomeGenNeptune extends BiomeGenBaseCelestial {
 		this.spawnableCaveCreatureList.clear();
 	}
 
+	@Override
+	public void decorate(
+		World world,
+		Random rand,
+		int x,
+		int z
+	) {
+		// no vanilla surface features in a gas giant atmosphere
+	}
 }

--- a/src/main/java/com/hbm/world/PlanetGen.java
+++ b/src/main/java/com/hbm/world/PlanetGen.java
@@ -19,6 +19,7 @@ import com.hbm.dim.moho.WorldGeneratorMoho;
 import com.hbm.dim.moho.WorldProviderMoho;
 import com.hbm.dim.moon.WorldGeneratorMoon;
 import com.hbm.dim.moon.WorldProviderMoon;
+import com.hbm.dim.neptune.WorldProviderNeptune;
 import com.hbm.dim.orbit.WorldProviderOrbit;
 import com.hbm.dim.saturn.WorldProviderSaturn;
 import com.hbm.dim.sun.WorldGeneratorSun;
@@ -63,6 +64,7 @@ public class PlanetGen {
 		registerDimension(SpaceConfig.jupiterDimension, WorldProviderJupiter.class);
 		registerDimension(SpaceConfig.saturnDimension, WorldProviderSaturn.class);
 		registerDimension(SpaceConfig.uranusDimension, WorldProviderUranus.class);
+		registerDimension(SpaceConfig.neptuneDimension, WorldProviderNeptune.class);
 
     }
 

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -229,6 +229,7 @@ body.dres=Ceres
 body.jool=Jupiter
 body.sarnus=Saturn
 body.uranus=Uranus
+body.neptune=Neptune
 
 bomb.detonated=Detonated successfully!
 bomb.incompatible=Device can not be triggered!
@@ -7055,3 +7056,8 @@ item.powder_spent_mox.name=Spent MOX-241 Pellet Powder
 item.powder_lead_irradiated.name=Spent Lead Absorber Pellet Powder
 item.dust_graphite.name=Spent Graphite Moderator Pellet Powder
 item.powder_spent_leu.name=Spent Low Enriched Uranium Pellet Powder
+tile.neptune_cloud_thin.name=Thin Neptune Methane Haze
+tile.neptune_cloud.name=Neptune Methane Cloud
+tile.neptune_cloud_dense.name=Dense Neptune Cloud
+tile.neptune_atmosphere_dense.name=Dense Neptune Atmosphere
+tile.neptune_storm.name=Neptune Storm Cell


### PR DESCRIPTION
### Motivation
- Finish adding a realistic Neptune planet/dimension with its own atmosphere, weather, biome, and block assets so the solar system feels complete and Neptune can be targeted/loaded like other planets. 

### Description
- Add configurable Neptune IDs and biomes in `SpaceConfig` via `neptuneDimension` and `neptuneBiome` and include Neptune in dimension registration in `PlanetGen`. 
- Add Neptune as a `CelestialBody` in `SolarSystem` with physical parameters and adjusted atmosphere composition (`Fluids.HELIUM4` and `Fluids.NGAS`) and a new `Body.NEPTUNE` enum entry. 
- Implement `WorldProviderNeptune` to provide chunk generation wiring, planet-wide biome layers, persistent storm weather, radiation effects by altitude, sky/fog colors, dim sunlight, and a ~16.1h rotation period. 
- Add Neptune-specific atmospheric blocks (`BlockNeptuneCloudThin`, `BlockNeptuneCloud`, `BlockNeptuneCloudDense`, `BlockNeptuneAtmosphereDense`, `BlockNeptuneStorm`), register them in `ModBlocks`, and use them from the existing `ChunkProviderNeptune` layered atmosphere logic. 
- Add Neptune biome classes (`BiomeGenBaseNeptune`, `BiomeGenNeptune`) that disable vanilla surface decoration and register English localizations for `body.neptune` and the new block names. 

### Testing
- Ran `git diff --check` with no problems reported.  
- Ran `./gradlew compileJava` which failed in this environment because Gradle 4.4.1 could not determine Java version `25.0.2` (environmental Java/Gradle mismatch), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d1746ffb48323aaa5331295b3866d)