### PR TITLE
Add bomb site wand and restrict CSGO bomb placement

### DIFF
--- a/src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java
+++ b/src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java
@@ -6,6 +6,7 @@ import com.hbm.explosion.vanillant.ExplosionVNT;
 import com.hbm.explosion.vanillant.standard.BlockAllocatorStandard;
 import com.hbm.explosion.vanillant.standard.BlockProcessorStandard;
 import com.hbm.main.MainRegistry;
+import com.hbm.saveddata.BombSiteSavedData;
 import com.hbm.tileentity.bomb.TileEntityCharge;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import net.minecraft.entity.EntityLivingBase;
@@ -13,11 +14,30 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 import org.apache.logging.log4j.Level;
 
 import java.util.List;
 
 public class BlockChargeC4CSGO extends BlockChargeC4 {
+
+	@Override
+	public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side) {
+		return isInBombSiteForSide(world, x, y, z, side) && super.canPlaceBlockOnSide(world, x, y, z, side);
+	}
+
+	private boolean isInBombSiteForSide(World world, int x, int y, int z, int side) {
+		if(world.isRemote) {
+			return true;
+		}
+
+		if(BombSiteSavedData.isBombSite(world, x, y, z)) {
+			return true;
+		}
+
+		ForgeDirection dir = ForgeDirection.getOrientation(side);
+		return BombSiteSavedData.isBombSite(world, x - dir.offsetX, y - dir.offsetY, z - dir.offsetZ);
+	}
 
 	@Override
 	public BombReturnCode explode(World world, int x, int y, int z) {
@@ -50,6 +70,7 @@ public class BlockChargeC4CSGO extends BlockChargeC4 {
 	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean ext) {
 		super.addInformation(stack, player, list, ext);
 		list.add(EnumChatFormatting.BLUE + "Does not drop blocks.");
+		list.add(EnumChatFormatting.RED + "Can only be placed inside defined bomb sites.");
 	}
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack itemStack) {

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -2740,6 +2740,7 @@ public class ModItems {
 	public static Item wand;
 	public static Item wand_s;
 	public static Item wand_d;
+	public static Item bomb_site_wand;
 
 	public static Item structure_single;
 	public static Item structure_solid;
@@ -6085,6 +6086,7 @@ public class ModItems {
 		wand = new ItemWand().setUnlocalizedName("wand_k").setMaxStackSize(1).setCreativeTab(MainRegistry.consumableTab).setFull3D().setTextureName(RefStrings.MODID + ":wand");
 		wand_s = new ItemWandS().setUnlocalizedName("wand_s").setMaxStackSize(1).setCreativeTab(MainRegistry.consumableTab).setFull3D().setTextureName(RefStrings.MODID + ":wand_s");
 		wand_d = new ItemWandD().setUnlocalizedName("wand_d").setMaxStackSize(1).setCreativeTab(MainRegistry.consumableTab).setFull3D().setTextureName(RefStrings.MODID + ":wand_d");
+		bomb_site_wand = new ItemBombSiteWand().setUnlocalizedName("bomb_site_wand").setMaxStackSize(1).setCreativeTab(MainRegistry.consumableTab).setFull3D().setTextureName(RefStrings.MODID + ":wand");
 
 		structure_single = new ItemStructureSingle().setUnlocalizedName("structure_single").setMaxStackSize(1).setCreativeTab(MainRegistry.partsTab).setFull3D().setTextureName(RefStrings.MODID + ":structure_single");
 		structure_solid = new ItemStructureSolid().setUnlocalizedName("structure_solid").setMaxStackSize(1).setCreativeTab(MainRegistry.partsTab).setFull3D().setTextureName(RefStrings.MODID + ":structure_solid");
@@ -9907,6 +9909,7 @@ public class ModItems {
 		GameRegistry.registerItem(wand, wand.getUnlocalizedName());
 		GameRegistry.registerItem(wand_s, wand_s.getUnlocalizedName());
 		GameRegistry.registerItem(wand_d, wand_d.getUnlocalizedName());
+		GameRegistry.registerItem(bomb_site_wand, bomb_site_wand.getUnlocalizedName());
 		GameRegistry.registerItem(structure_single, structure_single.getUnlocalizedName());
 		GameRegistry.registerItem(structure_solid, structure_solid.getUnlocalizedName());
 		GameRegistry.registerItem(structure_pattern, structure_pattern.getUnlocalizedName());

--- a/src/main/java/com/hbm/items/tool/ItemBombSiteWand.java
+++ b/src/main/java/com/hbm/items/tool/ItemBombSiteWand.java
@@ -1,0 +1,81 @@
+package com.hbm.items.tool;
+
+import java.util.List;
+
+import com.hbm.saveddata.BombSiteSavedData;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
+
+public class ItemBombSiteWand extends Item {
+
+	@Override
+	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean bool) {
+		list.add("Creative-only item");
+		list.add(EnumChatFormatting.YELLOW + "Right-click two corners to add a bomb site.");
+		list.add(EnumChatFormatting.YELLOW + "Sneak-right-click inside a site to remove it.");
+
+		if(stack.stackTagCompound != null && stack.stackTagCompound.getBoolean("hasPos")) {
+			list.add(EnumChatFormatting.AQUA + "First corner: " + stack.stackTagCompound.getInteger("x") + ", " + stack.stackTagCompound.getInteger("y") + ", " + stack.stackTagCompound.getInteger("z"));
+		} else {
+			list.add(EnumChatFormatting.AQUA + "No first corner set.");
+		}
+	}
+
+	@Override
+	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float hitX, float hitY, float hitZ) {
+		if(stack.stackTagCompound == null) {
+			stack.stackTagCompound = new NBTTagCompound();
+		}
+
+		if(world.isRemote) {
+			return true;
+		}
+
+		if(player.isSneaking()) {
+			int removed = BombSiteSavedData.getData(world).removeSitesAt(x, y, z);
+			stack.stackTagCompound.setBoolean("hasPos", false);
+			player.addChatMessage(new ChatComponentText(removed > 0 ? "Removed " + removed + " bomb site(s)." : "No bomb site contains this block."));
+			return true;
+		}
+
+		if(!stack.stackTagCompound.getBoolean("hasPos")) {
+			stack.stackTagCompound.setInteger("x", x);
+			stack.stackTagCompound.setInteger("y", y);
+			stack.stackTagCompound.setInteger("z", z);
+			stack.stackTagCompound.setBoolean("hasPos", true);
+			player.addChatMessage(new ChatComponentText("Bomb site first corner set at " + x + ", " + y + ", " + z + "."));
+		} else {
+			int startX = stack.stackTagCompound.getInteger("x");
+			int startY = stack.stackTagCompound.getInteger("y");
+			int startZ = stack.stackTagCompound.getInteger("z");
+			boolean added = BombSiteSavedData.getData(world).addSite(startX, startY, startZ, x, y, z);
+			stack.stackTagCompound.setBoolean("hasPos", false);
+			player.addChatMessage(new ChatComponentText(added ? "Bomb site added from " + startX + ", " + startY + ", " + startZ + " to " + x + ", " + y + ", " + z + "." : "That bomb site already exists."));
+		}
+
+		return true;
+	}
+
+	@Override
+	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if(stack.stackTagCompound == null) {
+			stack.stackTagCompound = new NBTTagCompound();
+		}
+
+		if(player.isSneaking()) {
+			stack.stackTagCompound.setBoolean("hasPos", false);
+
+			if(!world.isRemote) {
+				player.addChatMessage(new ChatComponentText("Cleared pending bomb site corner."));
+			}
+		}
+
+		return stack;
+	}
+}

--- a/src/main/java/com/hbm/saveddata/BombSiteSavedData.java
+++ b/src/main/java/com/hbm/saveddata/BombSiteSavedData.java
@@ -1,0 +1,162 @@
+package com.hbm.saveddata;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldSavedData;
+
+public class BombSiteSavedData extends WorldSavedData {
+
+	private static final String DATA_NAME = "hbmbombsites";
+
+	public final List<BombSite> sites = new ArrayList<BombSite>();
+
+	public BombSiteSavedData(String name) {
+		super(name);
+	}
+
+	public BombSiteSavedData() {
+		super(DATA_NAME);
+		this.markDirty();
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		sites.clear();
+
+		NBTTagList list = nbt.getTagList("sites", 10);
+		for(int i = 0; i < list.tagCount(); i++) {
+			sites.add(BombSite.readFromNBT(list.getCompoundTagAt(i)));
+		}
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		NBTTagList list = new NBTTagList();
+
+		for(BombSite site : sites) {
+			NBTTagCompound siteTag = new NBTTagCompound();
+			site.writeToNBT(siteTag);
+			list.appendTag(siteTag);
+		}
+
+		nbt.setTag("sites", list);
+	}
+
+	public boolean hasSiteAt(int x, int y, int z) {
+		for(BombSite site : sites) {
+			if(site.contains(x, y, z)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public boolean addSite(int x1, int y1, int z1, int x2, int y2, int z2) {
+		BombSite site = new BombSite(x1, y1, z1, x2, y2, z2);
+
+		for(BombSite existing : sites) {
+			if(existing.equals(site)) {
+				return false;
+			}
+		}
+
+		sites.add(site);
+		markDirty();
+		return true;
+	}
+
+	public int removeSitesAt(int x, int y, int z) {
+		int removed = 0;
+		Iterator<BombSite> iterator = sites.iterator();
+
+		while(iterator.hasNext()) {
+			if(iterator.next().contains(x, y, z)) {
+				iterator.remove();
+				removed++;
+			}
+		}
+
+		if(removed > 0) {
+			markDirty();
+		}
+
+		return removed;
+	}
+
+	public static BombSiteSavedData getData(World world) {
+		BombSiteSavedData data = (BombSiteSavedData) world.perWorldStorage.loadData(BombSiteSavedData.class, DATA_NAME);
+
+		if(data == null) {
+			world.perWorldStorage.setData(DATA_NAME, new BombSiteSavedData());
+			data = (BombSiteSavedData) world.perWorldStorage.loadData(BombSiteSavedData.class, DATA_NAME);
+		}
+
+		return data;
+	}
+
+	public static boolean isBombSite(World world, int x, int y, int z) {
+		return getData(world).hasSiteAt(x, y, z);
+	}
+
+	public static class BombSite {
+		public final int minX;
+		public final int minY;
+		public final int minZ;
+		public final int maxX;
+		public final int maxY;
+		public final int maxZ;
+
+		public BombSite(int x1, int y1, int z1, int x2, int y2, int z2) {
+			this.minX = Math.min(x1, x2);
+			this.minY = Math.min(y1, y2);
+			this.minZ = Math.min(z1, z2);
+			this.maxX = Math.max(x1, x2);
+			this.maxY = Math.max(y1, y2);
+			this.maxZ = Math.max(z1, z2);
+		}
+
+		public boolean contains(int x, int y, int z) {
+			return x >= minX && x <= maxX && y >= minY && y <= maxY && z >= minZ && z <= maxZ;
+		}
+
+		public void writeToNBT(NBTTagCompound nbt) {
+			nbt.setInteger("minX", minX);
+			nbt.setInteger("minY", minY);
+			nbt.setInteger("minZ", minZ);
+			nbt.setInteger("maxX", maxX);
+			nbt.setInteger("maxY", maxY);
+			nbt.setInteger("maxZ", maxZ);
+		}
+
+		public static BombSite readFromNBT(NBTTagCompound nbt) {
+			return new BombSite(nbt.getInteger("minX"), nbt.getInteger("minY"), nbt.getInteger("minZ"), nbt.getInteger("maxX"), nbt.getInteger("maxY"), nbt.getInteger("maxZ"));
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if(!(obj instanceof BombSite)) {
+				return false;
+			}
+
+			BombSite site = (BombSite) obj;
+			return minX == site.minX && minY == site.minY && minZ == site.minZ && maxX == site.maxX && maxY == site.maxY && maxZ == site.maxZ;
+		}
+
+		@Override
+		public int hashCode() {
+			int result = minX;
+			result = 31 * result + minY;
+			result = 31 * result + minZ;
+			result = 31 * result + maxX;
+			result = 31 * result + maxY;
+			result = 31 * result + maxZ;
+			return result;
+		}
+	}
+}

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -5050,6 +5050,7 @@ item.volcanic_axe.name=Molten Axe
 item.volcanic_pickaxe.name=Molten Pickaxe
 item.wand_d.name=Debug Wand
 item.wand_k.name=Construction Wand
+item.bomb_site_wand.name=Bomb Site Wand
 item.wand_s.name=Structure Wand
 item.structure_custommachine.name=Custom Machine Structure Output Wand
 item.warhead_buster_large.name=Large Bunker Buster Warhead


### PR DESCRIPTION
### Motivation
- Provide map authors/server admins a way to declare safe/allowed bomb sites and prevent players from placing the CSGO-style bomb outside those areas.
- Add a creative tool to define and remove cuboid bomb-site regions persisted per-world so sites survive restarts.

### Description
- Added `BombSiteSavedData` (per-world `WorldSavedData`) with NBT read/write, add/remove, duplicate checking and point-in-site lookup for cuboid sites (`src/main/java/com/hbm/saveddata/BombSiteSavedData.java`).
- Implemented a creative `ItemBombSiteWand` that sets two corners (right-click) to add a site, sneak-right-click inside a site to remove it, and clears the pending corner with sneak-right-click in air (`src/main/java/com/hbm/items/tool/ItemBombSiteWand.java`).
- Registered and localized the new wand (`ModItems` and `en_US.lang`) and reused the existing wand texture (`src/main/java/com/hbm/items/ModItems.java`, `src/main/resources/assets/hbm/lang/en_US.lang`).
- Restricted placement of the CSGO bomb so server-side placement only succeeds when the target block or the anchor block is inside a defined bomb site, while keeping client-side checks permissive to avoid client-side stale data blocking valid server placements; also added a tooltip note (`src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java`).

### Testing
- Ran `git diff --check` to validate whitespace and basic issues, which passed (only earlier trailing whitespace was corrected during edits). 
- Attempted `./gradlew compileJava` with the project wrapper but it failed due to the wrapper/Gradle version being incompatible with the installed Java (`25.0.2`).
- Attempted `gradle compileJava` with system Gradle; the build failed while resolving `ForgeGradle` metadata due to remote Maven endpoints returning HTTP `403 Forbidden`, preventing a clean compile in this environment.
- No full Java compilation or runtime tests completed in this environment because of the Java/Gradle and remote-repository access issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d3682bc28832386188211dcbe0c80)