### PR TITLE
Fix orbital sun glare brightness

### DIFF
--- a/src/main/java/com/hbm/dim/SkyProviderCelestial.java
+++ b/src/main/java/com/hbm/dim/SkyProviderCelestial.java
@@ -424,6 +424,10 @@ public class SkyProviderCelestial extends IRenderHandler {
 	}
 
 	protected void renderSun(float partialTicks, WorldClient world, Minecraft mc, double sunSize, double coronaSize, float visibility, float pressure) {
+		renderSun(partialTicks, world, mc, sunSize, coronaSize, visibility, pressure, 1.0F);
+	}
+
+	protected void renderSun(float partialTicks, WorldClient world, Minecraft mc, double sunSize, double coronaSize, float visibility, float pressure, float glareBrightness) {
 		Tessellator tessellator = Tessellator.instance;
 
 		if(SolarSystem.kerbol.shader != null && SolarSystem.kerbol.hasTrait(CBT_Destroyed.class)) {
@@ -481,8 +485,10 @@ public class SkyProviderCelestial extends IRenderHandler {
 			tessellator.addVertexWithUV(-sunSize, 100.0D, sunSize, 0.0D, 1.0D);
 			tessellator.draw();
 
-			// Draw a big ol' spiky flare! Less so when there is an atmosphere
-			GL11.glColor4f(1.0F, 1.0F, 1.0F, 1 - MathHelper.clamp_float(pressure, 0.0F, 1.0F) * 0.75F);
+			// Draw a big ol' spiky flare! Less so when there is an atmosphere,
+			// and scale the glare by irradiance for vacuum/orbital views.
+			float flareAlpha = MathHelper.clamp_float(glareBrightness, 0.0F, 1.0F) * (1 - MathHelper.clamp_float(pressure, 0.0F, 1.0F) * 0.75F);
+			GL11.glColor4f(1.0F, 1.0F, 1.0F, flareAlpha);
 
 			mc.renderEngine.bindTexture(flareTexture);
 

--- a/src/main/java/com/hbm/dim/orbit/SkyProviderOrbit.java
+++ b/src/main/java/com/hbm/dim/orbit/SkyProviderOrbit.java
@@ -67,7 +67,8 @@ public class SkyProviderOrbit extends SkyProviderCelestial {
 			}
 			double coronaSize = sunSize * (3 - Library.smoothstep(Math.abs(celestialPhase), 0.7, 0.8));
 
-			renderSun(partialTicks, world, mc, sunSize, coronaSize, 1, 0);
+			float sunGlare = provider.getSunBrightness(partialTicks);
+			renderSun(partialTicks, world, mc, sunSize, coronaSize, 1, 0, sunGlare);
 
 			CelestialBody orbiting = station.orbiting;
 


### PR DESCRIPTION
### Motivation
- Orbit views showed unrealistically strong sun glare regardless of distance or eclipse state, making stars and other bodies incorrectly obscured. 
- The goal is to modulate rendered sun flare by the computed orbital irradiance so the sun appears correctly dimmer in shadowed or distant orbital positions.

### Description
- Added a new overload `renderSun(..., float glareBrightness)` in `SkyProviderCelestial` and kept the existing signature delegating to it so callers remain compatible. 
- Scaled the flare alpha using the new `glareBrightness` parameter: `float flareAlpha = MathHelper.clamp_float(glareBrightness, 0.0F, 1.0F) * (1 - MathHelper.clamp_float(pressure, 0.0F, 1.0F) * 0.75F)`, replacing the previous constant-full intensity calculation. 
- Updated `SkyProviderOrbit` to pass the orbital irradiance (`provider.getSunBrightness(partialTicks)`) into the new `renderSun` overload so orbital rendering uses the same brightness metric. 
- Changes are limited to `src/main/java/com/hbm/dim/SkyProviderCelestial.java` and `src/main/java/com/hbm/dim/orbit/SkyProviderOrbit.java` and preserve existing behavior for non-orbit code paths.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed. 
- Attempted a full Java compile via `./gradlew compileJava`, which failed in the current environment due to the local Gradle/Java version mismatch (`Gradle 4.4.1 could not determine Java version 25.0.2`), so a successful compile could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d762c616c8323a5e0d25c9023341b)