### PR TITLE
Add molten salt reactor

### DIFF
--- a/src/main/java/com/hbm/blocks/ModBlocks.java
+++ b/src/main/java/com/hbm/blocks/ModBlocks.java
@@ -1033,6 +1033,7 @@ public class ModBlocks {
 	public static Block machine_rtg_grey;
 	public static Block machine_amgen;
 	public static Block machine_geo;
+	public static Block machine_molten_salt_reactor;
 	public static Block machine_minirtg;
 	public static Block machine_powerrtg;
 	public static Block machine_radiolysis;
@@ -2134,6 +2135,7 @@ public class ModBlocks {
 		machine_rtg_grey = new MachineRTG(Material.iron).setBlockName("machine_rtg_grey").setHardness(5.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab).setBlockTextureName(RefStrings.MODID + ":rtg");
 		machine_amgen = new MachineAmgen(Material.iron).setBlockName("machine_amgen").setHardness(5.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab);
 		machine_geo = new MachineAmgen(Material.iron).setBlockName("machine_geo").setHardness(5.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab);
+		machine_molten_salt_reactor = new MachineMoltenSaltReactor(Material.iron).setBlockName("machine_molten_salt_reactor").setHardness(5.0F).setResistance(100.0F).setCreativeTab(MainRegistry.machineTab).setBlockTextureName(RefStrings.MODID + ":block_steel_machine");
 		machine_minirtg = new MachineMiniRTG(Material.iron).setBlockName("machine_minirtg").setHardness(5.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab).setBlockTextureName(RefStrings.MODID + ":rtg_cell");
 		machine_powerrtg = new MachineMiniRTG(Material.iron).setBlockName("machine_powerrtg").setHardness(5.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab).setBlockTextureName(RefStrings.MODID + ":rtg_polonium");
 		machine_radiolysis = new MachineRadiolysis(Material.iron).setBlockName("machine_radiolysis").setHardness(10.0F).setResistance(10.0F).setCreativeTab(MainRegistry.machineTab).setBlockTextureName(RefStrings.MODID + ":block_steel_machine");
@@ -3522,6 +3524,7 @@ public class ModBlocks {
 		GameRegistry.registerBlock(machine_exposure_chamber, machine_exposure_chamber.getUnlocalizedName());
 		GameRegistry.registerBlock(machine_rtg_grey, machine_rtg_grey.getUnlocalizedName());
 		GameRegistry.registerBlock(machine_geo, machine_geo.getUnlocalizedName());
+		GameRegistry.registerBlock(machine_molten_salt_reactor, machine_molten_salt_reactor.getUnlocalizedName());
 		GameRegistry.registerBlock(machine_amgen, machine_amgen.getUnlocalizedName());
 		GameRegistry.registerBlock(machine_minirtg, machine_minirtg.getUnlocalizedName());
 		GameRegistry.registerBlock(machine_powerrtg, machine_powerrtg.getUnlocalizedName());

--- a/src/main/java/com/hbm/blocks/machine/MachineMoltenSaltReactor.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineMoltenSaltReactor.java
@@ -1,0 +1,55 @@
+package com.hbm.blocks.machine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hbm.blocks.ILookOverlay;
+import com.hbm.blocks.ITooltipProvider;
+import com.hbm.tileentity.machine.TileEntityMoltenSaltReactor;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.block.material.Material;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.client.event.RenderGameOverlayEvent.Pre;
+
+public class MachineMoltenSaltReactor extends BlockMachineBase implements ITooltipProvider, ILookOverlay {
+
+	public MachineMoltenSaltReactor(Material mat) {
+		super(mat, -1);
+	}
+
+	@Override
+	public TileEntity createNewTileEntity(World world, int meta) {
+		return new TileEntityMoltenSaltReactor();
+	}
+
+	@Override
+	public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean ext) {
+		list.add(EnumChatFormatting.YELLOW + "Heats liquid thorium salt into hot salt.");
+		list.add(EnumChatFormatting.YELLOW + "Pipe liquid thorium salt in and hot salt out.");
+	}
+
+	@Override
+	@SideOnly(Side.CLIENT)
+	public void printHook(Pre event, World world, int x, int y, int z) {
+		List<String> text = new ArrayList<String>();
+		TileEntity tile = world.getTileEntity(x, y, z);
+
+		if(tile instanceof TileEntityMoltenSaltReactor) {
+			TileEntityMoltenSaltReactor reactor = (TileEntityMoltenSaltReactor) tile;
+			text.add("Input: " + reactor.tanks[0].getFill() + "/" + reactor.tanks[0].getMaxFill() + " mB");
+			text.add("Output: " + reactor.tanks[1].getFill() + "/" + reactor.tanks[1].getMaxFill() + " mB");
+			text.add("Rate: " + reactor.output + " mB/t");
+		} else {
+			text.add("Pipe liquid thorium salt in.");
+			text.add("Pipe hot thorium salt out.");
+		}
+
+		ILookOverlay.printGeneric(event, "Molten Salt Reactor", 0xffa000, 0x402000, text);
+	}
+}

--- a/src/main/java/com/hbm/main/CraftingManager.java
+++ b/src/main/java/com/hbm/main/CraftingManager.java
@@ -990,6 +990,7 @@ public class CraftingManager {
 					  });
 
 		addRecipeAuto(new ItemStack(ModBlocks.machine_geo, 1), new Object[] { "ITI", "PCP", "ITI", 'I', DURA.ingot(), 'T', ModItems.thermo_element, 'P', CU.plateCast(), 'C', ModBlocks.red_wire_coated });
+		addRecipeAuto(new ItemStack(ModBlocks.machine_molten_salt_reactor, 1), new Object[] { "PTP", "SCS", "PTP", 'P', STEEL.pipe(), 'T', TH232.ingot(), 'S', STEEL.plate(), 'C', ModBlocks.machine_geo });
 		addRecipeAuto(new ItemStack(ModBlocks.machine_minirtg, 1), new Object[] { "LLL", "PPP", "TRT", 'L', PB.plate(), 'P', PU238.billet(), 'T', ModItems.thermo_element, 'R', ModItems.rtg_unit });
 		addRecipeAuto(new ItemStack(ModBlocks.machine_minirtg, 1), new Object[] { "LLL", "PPP", "TRT", 'L', PB.plate(), 'P', TM170.billet(), 'T', ModItems.thermo_element, 'R', ModItems.rtg_unit });
 		//addRecipeAuto(new ItemStack(ModBlocks.machine_minirtg, 1), new Object[] { "LLL", " P ", "TRT", 'L', PB.plate(), 'P', ModItems.ingot_thulium170, 'T', ModItems.thermo_element, 'R', ModItems.rtg_unit });

--- a/src/main/java/com/hbm/tileentity/TileMappings.java
+++ b/src/main/java/com/hbm/tileentity/TileMappings.java
@@ -147,6 +147,7 @@ public class TileMappings {
 		put(TileEntityCore.class, "tileentity_v0");
 		put(TileEntityMachineArcFurnace.class, "tileentity_arc_furnace");
 		put(TileEntityMachineAmgen.class, "tileentity_amgen");
+		put(TileEntityMoltenSaltReactor.class, "tileentity_molten_salt_reactor");
 		put(TileEntityGeysir.class, "tileentity_geysir");
 		put(TileEntityMachineMissileAssembly.class, "tileentity_missile_assembly");
 		put(TileEntityMachineRocketAssembly.class, "tileentity_rocket_assembly");

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMoltenSaltReactor.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMoltenSaltReactor.java
@@ -1,0 +1,115 @@
+package com.hbm.tileentity.machine;
+
+import com.hbm.inventory.fluid.Fluids;
+import com.hbm.inventory.fluid.tank.FluidTank;
+import com.hbm.tileentity.IFluidCopiable;
+import com.hbm.tileentity.TileEntityMachineBase;
+import com.hbm.util.CompatEnergyControl;
+
+import api.hbm.fluid.IFluidStandardTransceiver;
+import api.hbm.tile.IInfoProviderEC;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class TileEntityMoltenSaltReactor extends TileEntityMachineBase implements IFluidStandardTransceiver, IFluidCopiable, IInfoProviderEC {
+
+	public static final int SALT_CAPACITY = 16_000;
+	public static final int HOT_SALT_CAPACITY = 16_000;
+	public static final int SALT_PER_TICK = 4;
+
+	public FluidTank[] tanks;
+	public int output;
+
+	public TileEntityMoltenSaltReactor() {
+		super(0);
+		tanks = new FluidTank[2];
+		tanks[0] = new FluidTank(Fluids.THORIUM_SALT, SALT_CAPACITY);
+		tanks[1] = new FluidTank(Fluids.THORIUM_SALT_HOT, HOT_SALT_CAPACITY);
+	}
+
+	@Override
+	public String getName() {
+		return "container.moltenSaltReactor";
+	}
+
+	@Override
+	public void updateEntity() {
+		if(!worldObj.isRemote) {
+			this.output = 0;
+			this.updateConnections();
+
+			int operations = Math.min(SALT_PER_TICK, tanks[0].getFill());
+			operations = Math.min(operations, tanks[1].getMaxFill() - tanks[1].getFill());
+
+			if(operations > 0) {
+				tanks[0].setFill(tanks[0].getFill() - operations);
+				tanks[1].setFill(tanks[1].getFill() + operations);
+				this.output = operations;
+			}
+
+			this.subscribeToAllAround(tanks[0].getTankType(), this);
+			this.sendFluidToAll(tanks[1], this);
+
+			NBTTagCompound data = new NBTTagCompound();
+			data.setInteger("output", output);
+			tanks[0].writeToNBT(data, "salt");
+			tanks[1].writeToNBT(data, "hotSalt");
+			this.networkPack(data, 50);
+		}
+	}
+
+	protected void updateConnections() {
+		for(ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS)
+			this.trySubscribe(worldObj, xCoord + dir.offsetX, yCoord + dir.offsetY, zCoord + dir.offsetZ, dir);
+	}
+
+	@Override
+	public void networkUnpack(NBTTagCompound data) {
+		super.networkUnpack(data);
+		this.output = data.getInteger("output");
+		tanks[0].readFromNBT(data, "salt");
+		tanks[1].readFromNBT(data, "hotSalt");
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		super.readFromNBT(nbt);
+		this.output = nbt.getInteger("output");
+		tanks[0].readFromNBT(nbt, "salt");
+		tanks[1].readFromNBT(nbt, "hotSalt");
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		super.writeToNBT(nbt);
+		nbt.setInteger("output", output);
+		tanks[0].writeToNBT(nbt, "salt");
+		tanks[1].writeToNBT(nbt, "hotSalt");
+	}
+
+	@Override
+	public FluidTank[] getSendingTanks() {
+		return new FluidTank[] { tanks[1] };
+	}
+
+	@Override
+	public FluidTank[] getReceivingTanks() {
+		return new FluidTank[] { tanks[0] };
+	}
+
+	@Override
+	public FluidTank[] getAllTanks() {
+		return tanks;
+	}
+
+	@Override
+	public FluidTank getTankToPaste() {
+		return tanks[0];
+	}
+
+	@Override
+	public void provideExtraInfo(NBTTagCompound data) {
+		data.setBoolean(CompatEnergyControl.B_ACTIVE, this.output > 0);
+		data.setDouble(CompatEnergyControl.D_OUTPUT_MB, this.output);
+	}
+}

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -7067,3 +7067,6 @@ tile.supercritical_hydrogen.name=Supercritical Hydrogen
 tile.metallic_hydrogen.name=Metallic Hydrogen Fluid
 tile.supercritical_water.name=Supercritical Water
 tile.ammonia_water.name=Water-Ammonia Slurry
+
+tile.machine_molten_salt_reactor.name=Molten Salt Reactor
+container.moltenSaltReactor=Molten Salt Reactor


### PR DESCRIPTION
### Motivation
- Provide a new molten salt reactor machine that heats liquid thorium salt into hot thorium salt for downstream heat extraction and integration with the existing fluid network.
- Expose fluid I/O and compact processing behavior so the new block can be piped into the mod's heat systems and monitored by existing EC/overlay tooling.
- Add a simple crafting path and localization so the machine is available in-game.

### Description
- Added `MachineMoltenSaltReactor` (new block) with tooltip and overlay display showing input/output tank levels and `mB/t` rate in `src/main/java/com/hbm/blocks/machine/MachineMoltenSaltReactor.java`.
- Added `TileEntityMoltenSaltReactor` implementing `IFluidStandardTransceiver` with two `FluidTank`s (16,000 mB each) that convert `Fluids.THORIUM_SALT` into `Fluids.THORIUM_SALT_HOT` at up to `4 mB/t`, plus NBT/network sync and EC extra-info in `src/main/java/com/hbm/tileentity/machine/TileEntityMoltenSaltReactor.java`.
- Registered the block and tile mapping in `ModBlocks.java` and `TileMappings.java`, registered the block with `GameRegistry`, added a crafting recipe to `CraftingManager.java`, and added English localization keys to `src/main/resources/assets/hbm/lang/en_US.lang`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which passed after a trailing-whitespace fix.
- Attempted `./gradlew compileJava` to compile the mod, which failed in this environment because Gradle 4.4.1 cannot determine Java version `25.0.2` (build error), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1db34407fc8323bec70f7885c482d6)