### PR TITLE
CSGO C4: preserve terrain while showing larger explosion particles

### DIFF
--- a/src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java
+++ b/src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java
@@ -3,8 +3,6 @@ package com.hbm.blocks.bomb;
 import com.hbm.config.GeneralConfig;
 import com.hbm.explosion.ExplosionLarge;
 import com.hbm.explosion.vanillant.ExplosionVNT;
-import com.hbm.explosion.vanillant.standard.BlockAllocatorStandard;
-import com.hbm.explosion.vanillant.standard.BlockProcessorStandard;
 import com.hbm.main.MainRegistry;
 import com.hbm.saveddata.BombSiteSavedData;
 import com.hbm.tileentity.bomb.TileEntityCharge;
@@ -48,10 +46,10 @@ public class BlockChargeC4CSGO extends BlockChargeC4 {
 			safe = false;
 
 			ExplosionVNT xnt = new ExplosionVNT(world, x + 0.5, y + 0.5, z + 0.5, 30F).makeStandard();
-			xnt.setBlockAllocator(new BlockAllocatorStandard(32));
-			xnt.setBlockProcessor(new BlockProcessorStandard().setNoDrop());
+			xnt.setBlockAllocator(null);
+			xnt.setBlockProcessor(null);
 			xnt.explode();
-			ExplosionLarge.spawnParticles(world, x + 0.5, y + 0.5, z + 0.5, 50);
+			ExplosionLarge.spawnParticles(world, x + 0.5, y + 0.5, z + 0.5, 250);
 
 			return BombReturnCode.DETONATED;
 		}


### PR DESCRIPTION
### Motivation
- Make the CSGO-style C4 detonation preserve surrounding terrain while still displaying the explosion particle FX and make the C4 particle FX visibly larger (5×). 

### Description
- Change `BlockChargeC4CSGO.explode` to run the `ExplosionVNT` without block allocation/processing (set allocator and processor to `null`) so blocks are not destroyed and increase the smoke cloud particle count in `ExplosionLarge.spawnParticles` from `50` to `250` (file: `src/main/java/com/hbm/blocks/bomb/BlockChargeC4CSGO.java`).

### Testing
- Ran `git diff --check` which completed cleanly; attempted `./gradlew compileJava` but compilation is blocked by the environment Gradle/Java mismatch (Gradle 4.4.1 could not determine Java runtime version), and attempts to switch Java (`JAVA_HOME=$(mise where java@11.0.2) ./gradlew compileJava`) and install Java 8 via `mise` failed due to environment/network issues, so a full compile could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eaef2f7708323a0eb12ece2d12608)