### PR TITLE
Add RenderStateGuard to isolate legacy OpenGL state and update renderers to use it

### DIFF
--- a/src/main/java/com/hbm/config/ClientConfig.java
+++ b/src/main/java/com/hbm/config/ClientConfig.java
@@ -40,6 +40,7 @@ public class ClientConfig {
 	public static ConfigWrapper<Boolean> NUKE_HUD_FLASH =					new ConfigWrapper(true);
 	public static ConfigWrapper<Boolean> NUKE_HUD_SHAKE =					new ConfigWrapper(true);
 	public static ConfigWrapper<Boolean> RENDER_REEDS =						new ConfigWrapper(!Compat.isModLoaded(Compat.MOD_ANG));
+	public static ConfigWrapper<Boolean> DEBUG_RENDER_GL_ERRORS =			new ConfigWrapper(false);
 
 	private static void initDefaults() {
 		configMap.put("GEIGER_OFFSET_HORIZONTAL", GEIGER_OFFSET_HORIZONTAL);
@@ -58,6 +59,7 @@ public class ClientConfig {
 		configMap.put("NUKE_HUD_FLASH", NUKE_HUD_FLASH);
 		configMap.put("NUKE_HUD_SHAKE", NUKE_HUD_SHAKE);
 		configMap.put("RENDER_REEDS", RENDER_REEDS);
+		configMap.put("DEBUG_RENDER_GL_ERRORS", DEBUG_RENDER_GL_ERRORS);
 	}
 
 	/** Initializes defaults, then reads the config file if it exists, then writes the config file. */

--- a/src/main/java/com/hbm/render/RenderStateGuard.java
+++ b/src/main/java/com/hbm/render/RenderStateGuard.java
@@ -1,0 +1,110 @@
+package com.hbm.render;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.util.glu.GLU;
+
+import com.hbm.config.ClientConfig;
+import com.hbm.main.MainRegistry;
+
+import net.minecraft.client.renderer.OpenGlHelper;
+
+/**
+ * Fixed-function state boundary for legacy render callbacks.
+ *
+ * Angelica and similar renderers track GL state in software, so render callbacks
+ * must not leak raw LWJGL state into the next callback. This guard deliberately
+ * uses the compatibility-profile attribute stack and a modelview matrix scope.
+ */
+public final class RenderStateGuard {
+
+	private static final ThreadLocal<Deque<String>> CONTEXTS = new ThreadLocal<Deque<String>>() {
+		@Override
+		protected Deque<String> initialValue() {
+			return new ArrayDeque<String>();
+		}
+	};
+
+	private RenderStateGuard() { }
+
+	public static void push(String context) {
+		checkGLError(context + " before push");
+		GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+		GL11.glMatrixMode(GL11.GL_MODELVIEW);
+		GL11.glPushMatrix();
+		CONTEXTS.get().push(context);
+	}
+
+	public static void pop(String context) {
+		Deque<String> contexts = CONTEXTS.get();
+		String pushed = contexts.isEmpty() ? null : contexts.pop();
+		GL11.glMatrixMode(GL11.GL_MODELVIEW);
+		GL11.glPopMatrix();
+		GL11.glPopAttrib();
+		GL11.glMatrixMode(GL11.GL_MODELVIEW);
+		if(pushed != null && !pushed.equals(context) && ClientConfig.DEBUG_RENDER_GL_ERRORS.get()) {
+			MainRegistry.logger.warn("Render state guard mismatch: pushed '" + pushed + "' but popped '" + context + "'");
+		}
+		checkGLError(context + " after pop");
+	}
+
+	public static void pushMatrix() { GL11.glPushMatrix(); }
+	public static void popMatrix() { GL11.glPopMatrix(); }
+	public static void pushAttrib() { GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS); }
+	public static void popAttrib() { GL11.glPopAttrib(); }
+
+	public static void resetColor() { GL11.glColor4f(1F, 1F, 1F, 1F); }
+	public static void safeBlendOn() {
+		GL11.glEnable(GL11.GL_BLEND);
+		OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, GL11.GL_ONE, GL11.GL_ZERO);
+	}
+	public static void safeBlendOff() { GL11.glDisable(GL11.GL_BLEND); }
+	public static void safeAlphaOn() {
+		GL11.glEnable(GL11.GL_ALPHA_TEST);
+		GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
+	}
+	public static void safeCullOn() {
+		GL11.glEnable(GL11.GL_CULL_FACE);
+		GL11.glCullFace(GL11.GL_BACK);
+	}
+	public static void safeCullOff() { GL11.glDisable(GL11.GL_CULL_FACE); }
+	public static void safeDepthWriteOn() { GL11.glDepthMask(true); }
+	public static void safeDepthWriteOff() { GL11.glDepthMask(false); }
+	public static void safeLightingOn() { GL11.glEnable(GL11.GL_LIGHTING); }
+	public static void safeLightingOff() { GL11.glDisable(GL11.GL_LIGHTING); }
+	public static void safeRescaleNormalOn() { GL11.glEnable(GL12.GL_RESCALE_NORMAL); }
+	public static void safeRescaleNormalOff() { GL11.glDisable(GL12.GL_RESCALE_NORMAL); }
+
+	public static void safeDefaultBlockState() {
+		GL11.glMatrixMode(GL11.GL_MODELVIEW);
+		resetColor();
+		safeBlendOff();
+		safeAlphaOn();
+		safeCullOn();
+		safeDepthWriteOn();
+		safeLightingOn();
+		safeRescaleNormalOff();
+		GL11.glEnable(GL11.GL_DEPTH_TEST);
+		GL11.glEnable(GL11.GL_TEXTURE_2D);
+		GL11.glShadeModel(GL11.GL_FLAT);
+	}
+
+	public static void safeDefaultItemState() {
+		safeDefaultBlockState();
+	}
+
+	public static void safeDefaultTESRState() {
+		safeDefaultBlockState();
+	}
+
+	public static void checkGLError(String context) {
+		if(!ClientConfig.DEBUG_RENDER_GL_ERRORS.get()) return;
+		int error;
+		while((error = GL11.glGetError()) != GL11.GL_NO_ERROR) {
+			MainRegistry.logger.warn("OpenGL error in " + context + ": " + error + " (" + GLU.gluErrorString(error) + ")");
+		}
+	}
+}

--- a/src/main/java/com/hbm/render/entity/effect/FogRenderer.java
+++ b/src/main/java/com/hbm/render/entity/effect/FogRenderer.java
@@ -7,6 +7,7 @@ import org.lwjgl.opengl.GL12;
 
 import com.hbm.entity.particle.EntityModFX;
 import com.hbm.lib.RefStrings;
+import com.hbm.render.RenderStateGuard;
 
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
@@ -19,8 +20,9 @@ public class FogRenderer extends Render {
 	@Override
 	public void doRender(Entity p_76986_1_, double p_76986_2_, double p_76986_4_, double p_76986_6_, float p_76986_8_,
 			float p_76986_9_) {
-		
-		GL11.glPushMatrix();
+		RenderStateGuard.push("FogRenderer");
+		try {
+			GL11.glPushMatrix();
 		GL11.glTranslatef((float) p_76986_2_, (float) p_76986_4_, (float) p_76986_6_);
 		GL11.glEnable(GL12.GL_RESCALE_NORMAL);
 		GL11.glDisable(GL11.GL_LIGHTING);
@@ -87,7 +89,12 @@ public class FogRenderer extends Render {
         //GL11.glEnable(GL11.GL_DEPTH_TEST);
         GL11.glDepthMask(true);
         
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("FogRenderer");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/entity/effect/RenderCloudTom.java
+++ b/src/main/java/com/hbm/render/entity/effect/RenderCloudTom.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.hbm.entity.effect.EntityCloudTom;
 import com.hbm.main.ResourceManager;
+import com.hbm.render.RenderStateGuard;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -17,8 +18,9 @@ public class RenderCloudTom extends Render {
 
 	@Override
 	public void doRender(Entity entity, double x, double y, double z, float f0, float f1) {
-		
-		GL11.glPushMatrix();
+		RenderStateGuard.push("RenderCloudTom");
+		try {
+			GL11.glPushMatrix();
 		GL11.glTranslated(x, y, z);
         GL11.glDisable(GL11.GL_LIGHTING);
         GL11.glEnable(GL11.GL_BLEND);
@@ -92,7 +94,12 @@ public class RenderCloudTom extends Render {
         GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderCloudTom");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
 	}
 
 	@Override

--- a/src/main/java/com/hbm/render/item/ItemRendererHot.java
+++ b/src/main/java/com/hbm/render/item/ItemRendererHot.java
@@ -3,6 +3,7 @@ package com.hbm.render.item;
 import org.lwjgl.opengl.GL11;
 
 import com.hbm.items.special.ItemHot;
+import com.hbm.render.RenderStateGuard;
 import com.hbm.render.util.RenderItemStack;
 
 import net.minecraft.client.Minecraft;
@@ -26,7 +27,9 @@ public class ItemRendererHot implements IItemRenderer {
 
 	@Override
 	public void renderItem(ItemRenderType type, ItemStack item, Object... data) {
-		GL11.glPushMatrix();
+		RenderStateGuard.push("ItemRendererHot");
+		try {
+			GL11.glPushMatrix();
 		RenderHelper.enableGUIStandardItemLighting();
 		
 		Minecraft mc = Minecraft.getMinecraft();
@@ -44,6 +47,11 @@ public class ItemRendererHot implements IItemRenderer {
             GL11.glDisable(GL11.GL_BLEND);
 		}
 		
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("ItemRendererHot");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultItemState();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/item/weapon/ItemRenderWeaponMiniFEL.java
+++ b/src/main/java/com/hbm/render/item/weapon/ItemRenderWeaponMiniFEL.java
@@ -89,6 +89,7 @@ public class ItemRenderWeaponMiniFEL implements IItemRenderer {
                     break;
             }
 
+            GL11.glPopMatrix();
         }
 
     }

--- a/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
+++ b/src/main/java/com/hbm/render/item/weapon/sedna/ItemRenderWeaponBase.java
@@ -5,6 +5,7 @@ import org.lwjgl.opengl.GL12;
 import org.lwjgl.util.glu.Project;
 
 import com.hbm.items.weapon.sedna.ItemGunBaseNT;
+import com.hbm.render.RenderStateGuard;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
@@ -48,34 +49,51 @@ public abstract class ItemRenderWeaponBase implements IItemRenderer {
 	}
 
 	public void setPerspectiveAndRender(ItemStack stack, float interp) {
-		
-		this.interp = interp;
-		
-		Minecraft mc = Minecraft.getMinecraft();
-		EntityRenderer entityRenderer = mc.entityRenderer;
-		float farPlaneDistance = mc.gameSettings.renderDistanceChunks * 16;
-
-		GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
+		RenderStateGuard.push("ItemRenderWeaponBase.setPerspectiveAndRender");
 		GL11.glMatrixMode(GL11.GL_PROJECTION);
-		GL11.glLoadIdentity();
-
-		Project.gluPerspective(this.getFOVModifier(interp, false), (float) mc.displayWidth / (float) mc.displayHeight, 0.05F, farPlaneDistance * 2.0F);
-
-		GL11.glMatrixMode(GL11.GL_MODELVIEW);
-		GL11.glLoadIdentity();
-
 		GL11.glPushMatrix();
+		GL11.glMatrixMode(GL11.GL_MODELVIEW);
+		GL11.glPushMatrix();
+		try {
+			this.interp = interp;
 
-		if(mc.gameSettings.thirdPersonView == 0 && !mc.renderViewEntity.isPlayerSleeping() && !mc.gameSettings.hideGUI && !mc.playerController.enableEverythingIsScrewedUpMode()) {
-			entityRenderer.enableLightmap(interp);
-			this.setupTransformsAndRender(stack);
-			entityRenderer.disableLightmap(interp);
-		}
+			Minecraft mc = Minecraft.getMinecraft();
+			EntityRenderer entityRenderer = mc.entityRenderer;
+			float farPlaneDistance = mc.gameSettings.renderDistanceChunks * 16;
 
-		GL11.glPopMatrix();
+			GL11.glClear(GL11.GL_DEPTH_BUFFER_BIT);
+			GL11.glMatrixMode(GL11.GL_PROJECTION);
+			GL11.glLoadIdentity();
+			Project.gluPerspective(this.getFOVModifier(interp, false), (float) mc.displayWidth / (float) mc.displayHeight, 0.05F, farPlaneDistance * 2.0F);
 
-		if(mc.gameSettings.thirdPersonView == 0 && !mc.renderViewEntity.isPlayerSleeping()) {
-			entityRenderer.itemRenderer.renderOverlays(interp);
+			GL11.glMatrixMode(GL11.GL_MODELVIEW);
+			GL11.glLoadIdentity();
+			GL11.glPushMatrix();
+
+			if(mc.gameSettings.thirdPersonView == 0 && !mc.renderViewEntity.isPlayerSleeping() && !mc.gameSettings.hideGUI && !mc.playerController.enableEverythingIsScrewedUpMode()) {
+				entityRenderer.enableLightmap(interp);
+				try {
+					this.setupTransformsAndRender(stack);
+				} finally {
+					entityRenderer.disableLightmap(interp);
+				}
+			}
+
+			GL11.glPopMatrix();
+
+			if(mc.gameSettings.thirdPersonView == 0 && !mc.renderViewEntity.isPlayerSleeping()) {
+				entityRenderer.itemRenderer.renderOverlays(interp);
+			}
+		} finally {
+			// The custom hand FOV must never replace the world projection used by later passes.
+			GL11.glMatrixMode(GL11.GL_MODELVIEW);
+			GL11.glPopMatrix();
+			GL11.glMatrixMode(GL11.GL_PROJECTION);
+			GL11.glPopMatrix();
+			GL11.glMatrixMode(GL11.GL_MODELVIEW);
+			RenderStateGuard.pop("ItemRenderWeaponBase.setPerspectiveAndRender");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultItemState();
 		}
 	}
 

--- a/src/main/java/com/hbm/render/tileentity/RenderCore.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderCore.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import org.lwjgl.opengl.GL11;
 
 import com.hbm.main.ResourceManager;
+import com.hbm.render.RenderStateGuard;
 import com.hbm.render.util.RenderSparks;
 import com.hbm.tileentity.machine.TileEntityCore;
 
@@ -207,9 +208,10 @@ public class RenderCore extends TileEntitySpecialRenderer {
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 	}
 	
-    public void renderVoid(TileEntity tile, double x, double y, double z) {
-        
-        TileEntityCore core = (TileEntityCore)tile;
+	    public void renderVoid(TileEntity tile, double x, double y, double z) {
+		RenderStateGuard.push("RenderCore.renderVoid");
+		try {
+	        TileEntityCore core = (TileEntityCore)tile;
 
 		World world = tile.getWorldObj();
         GL11.glPushMatrix();
@@ -358,7 +360,12 @@ public class RenderCore extends TileEntitySpecialRenderer {
 		GL11.glDisable(GL11.GL_TEXTURE_GEN_R);
 		GL11.glDisable(GL11.GL_TEXTURE_GEN_Q);
 		GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderCore.renderVoid");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
     }
 
     private FloatBuffer func_147525_a(float x, float y, float z, float w) {

--- a/src/main/java/com/hbm/render/tileentity/RenderMultiblock.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderMultiblock.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.hbm.blocks.ModBlocks;
 import com.hbm.lib.RefStrings;
+import com.hbm.render.RenderStateGuard;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -20,8 +21,9 @@ public class RenderMultiblock extends TileEntitySpecialRenderer {
 
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float f) {
-
-		GL11.glPushMatrix();
+		RenderStateGuard.push("RenderMultiblock");
+		try {
+			GL11.glPushMatrix();
 		
 		GL11.glTranslatef((float)x + 1, (float)y + 1, (float)z);
 
@@ -42,8 +44,13 @@ public class RenderMultiblock extends TileEntitySpecialRenderer {
 		GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
 		
-		GL11.glPopMatrix();
-	}
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderMultiblock");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
+		}
 	
 	private void renderCompactLauncher() {
 		

--- a/src/main/java/com/hbm/render/tileentity/RenderPlasmaMultiblock.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderPlasmaMultiblock.java
@@ -3,6 +3,7 @@ package com.hbm.render.tileentity;
 import org.lwjgl.opengl.GL11;
 
 import com.hbm.blocks.ModBlocks;
+import com.hbm.render.RenderStateGuard;
 import com.hbm.render.util.IconUtil;
 import com.hbm.render.util.SmallBlockPronter;
 
@@ -15,8 +16,9 @@ public class RenderPlasmaMultiblock extends TileEntitySpecialRenderer {
 
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float f) {
-
-		GL11.glPushMatrix();
+		RenderStateGuard.push("RenderPlasmaMultiblock");
+		try {
+			GL11.glPushMatrix();
 		
 		GL11.glTranslatef((float)x + 0.5F, (float)y, (float)z + 0.5F);
 		
@@ -62,6 +64,11 @@ public class RenderPlasmaMultiblock extends TileEntitySpecialRenderer {
         GL11.glDepthMask(true);
 
         GL11.glEnable(GL11.GL_LIGHTING);
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderPlasmaMultiblock");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/tileentity/RenderSoyuzMultiblock.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderSoyuzMultiblock.java
@@ -4,6 +4,7 @@ import org.lwjgl.opengl.GL11;
 
 import com.hbm.blocks.ModBlocks;
 import com.hbm.lib.RefStrings;
+import com.hbm.render.RenderStateGuard;
 
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -19,8 +20,9 @@ public class RenderSoyuzMultiblock extends TileEntitySpecialRenderer {
 
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float f) {
-
-		GL11.glPushMatrix();
+		RenderStateGuard.push("RenderSoyuzMultiblock");
+		try {
+			GL11.glPushMatrix();
 		
 		GL11.glTranslatef((float)x + 1, (float)y + 1, (float)z);
 
@@ -108,8 +110,13 @@ public class RenderSoyuzMultiblock extends TileEntitySpecialRenderer {
 		GL11.glDisable(GL11.GL_BLEND);
         GL11.glEnable(GL11.GL_ALPHA_TEST);
 		
-		GL11.glPopMatrix();
-	}
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderSoyuzMultiblock");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
+		}
 	
 	public void renderSmolBlockAt(ResourceLocation loc, int x, int y, int z) {
 		GL11.glPushMatrix();

--- a/src/main/java/com/hbm/render/tileentity/RenderVol2.java
+++ b/src/main/java/com/hbm/render/tileentity/RenderVol2.java
@@ -3,6 +3,7 @@ package com.hbm.render.tileentity;
 import org.lwjgl.opengl.GL11;
 
 import com.hbm.blocks.BlockVolcanoV2.TileEntityLightningVolcano;
+import com.hbm.render.RenderStateGuard;
 import com.hbm.render.util.BeamPronter;
 import com.hbm.render.util.BeamPronter.EnumBeamType;
 import com.hbm.render.util.BeamPronter.EnumWaveType;
@@ -15,8 +16,9 @@ public class RenderVol2 extends TileEntitySpecialRenderer {
 
 	@Override
 	public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float f) {
-		
-		GL11.glPushMatrix();
+		RenderStateGuard.push("RenderVol2");
+		try {
+			GL11.glPushMatrix();
 		GL11.glTranslated(x + 0.5, y, z + 0.5);
 		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glEnable(GL11.GL_CULL_FACE);
@@ -54,6 +56,11 @@ public class RenderVol2 extends TileEntitySpecialRenderer {
 
 		GL11.glEnable(GL11.GL_LIGHTING);
 
-		GL11.glPopMatrix();
+			GL11.glPopMatrix();
+		} finally {
+			RenderStateGuard.pop("RenderVol2");
+			RenderStateGuard.resetColor();
+			RenderStateGuard.safeDefaultTESRState();
+		}
 	}
 }

--- a/src/main/java/com/hbm/render/util/RenderScreenOverlay.java
+++ b/src/main/java/com/hbm/render/util/RenderScreenOverlay.java
@@ -118,8 +118,6 @@ public class RenderScreenOverlay {
 		GL11.glDisable(GL11.GL_BLEND);
 		GL11.glPopMatrix();
 		Minecraft.getMinecraft().renderEngine.bindTexture(Gui.icons);
-		GL11.glPopMatrix();
-		Minecraft.getMinecraft().renderEngine.bindTexture(Gui.icons);
 	}
 
 	public static void renderAmmo(ScaledResolution resolution, Gui gui, ItemStack ammo, int count, int max, int dura, boolean renderCount) {

--- a/src/main/java/com/hbm/render/util/SmallBlockPronter.java
+++ b/src/main/java/com/hbm/render/util/SmallBlockPronter.java
@@ -88,6 +88,7 @@ public class SmallBlockPronter {
 		GL11.glEnable(GL11.GL_ALPHA_TEST);
 		GL11.glDepthMask(true);
 		GL11.glEnable(GL11.GL_LIGHTING);
+		GL11.glColor4f(1F, 1F, 1F, 1F);
 	}
 	
 	public static void drawSmolBlockAt(Block b, int meta, float x, float y, float z) {


### PR DESCRIPTION
### Motivation

- Prevent raw LWJGL/OpenGL state from leaking between legacy render callbacks by providing a fixed-function state boundary. 
- Make GL error reporting optional and controllable via configuration to help debug rendering issues. 
- Ensure renderers reliably restore a known default GL state after drawing to reduce visual corruption between passes.

### Description

- Add `RenderStateGuard` utility that provides `push`/`pop` context tracking, common safe GL helper methods (blend, culling, lighting, depth mask, color reset, and default state presets), and optional GL error checking when `ClientConfig.DEBUG_RENDER_GL_ERRORS` is enabled. 
- Introduce a new client config flag `DEBUG_RENDER_GL_ERRORS` and register it in `ClientConfig`. 
- Update many renderers (`FogRenderer`, `RenderCloudTom`, `ItemRendererHot`, `ItemRenderWeaponBase`, `RenderCore`, `RenderMultiblock`, `RenderPlasmaMultiblock`, `RenderSoyuzMultiblock`, `RenderVol2`, and others) to call `RenderStateGuard.push(...)` before doing GL work and `RenderStateGuard.pop(...)` in a `finally` block, and to call `RenderStateGuard.resetColor()` and appropriate `safeDefault*State()` after pop. 
- Fix/move a number of `glPushMatrix`/`glPopMatrix` placements and wrap lightmap enable/disable in try/finally in `ItemRenderWeaponBase.setPerspectiveAndRender` to guarantee restoration of projection/modelview matrices. 
- Minor rendering cleanup such as restoring color in `SmallBlockPronter.draw()`.

### Testing

- Project build executed via the repository build task (`./gradlew build`) and compilation succeeded without errors. 
- No automated unit tests were present or modified in this change set, so no unit tests were run. 
- Smoke-tested by running the client briefly to exercise updated renderer code paths; no GL exceptions or crashes occurred during the quick smoke run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f97f31e388323bdcdebdb1238af16)