### PR TITLE
Fix NEI crash from unresolved assembler recipe ingredients

### DIFF
--- a/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
+++ b/src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java
@@ -5378,8 +5378,23 @@ public class AssemblerRecipes extends SerializableRecipe {
 			List<Object> value = new ArrayList();
 			AssemblerRecipe recipe = entry.getValue();
 
-			for (AStack o : recipe.ingredients) {
-				value.add(o.extractForNEI());
+			for (AStack ingredient : recipe.ingredients) {
+				List<ItemStack> extracted = ingredient.extractForNEI();
+				List<ItemStack> valid = new ArrayList();
+
+				if (extracted != null) {
+					for (ItemStack stack : extracted) {
+						if (stack != null && stack.getItem() != null) valid.add(stack);
+					}
+				}
+
+				if (valid.isEmpty()) {
+					ItemStack missing = new ItemStack(ModItems.nothing).setStackDisplayName("Missing assembler ingredient; check the console.");
+					valid.add(missing);
+					MainRegistry.logger.error("Assembler cannot compile an ingredient for NEI in recipe for: " + entry.getKey().toStack().getDisplayName());
+				}
+
+				value.add(valid);
 			}
 
 			recipes.put(entry.getKey()


### PR DESCRIPTION
### Motivation
- Viewing some assembler recipes (e.g. Large Mining Drill) could crash the client because NEI received null / invalid `ItemStack` entries produced by `AStack.extractForNEI()` and later dereferenced during recipe-ID extraction.
- The goal is to ensure the assembler -> NEI export always supplies valid stacks so NEI UI code never dereferences a null.

### Description
- Harden `AssemblerRecipes.getRecipes()` so each ingredient is expanded with `extractForNEI()`, then filtered to remove `null` stacks and stacks whose `getItem()` is `null` before exposing them to NEI.
- If an ingredient resolves to an empty/invalid list, substitute a diagnostic placeholder `ItemStack(ModItems.nothing)` with a display name and log an error identifying the affected assembler output so missing ore-dictionary entries remain diagnosable.
- The change is localized to `src/main/java/com/hbm/inventory/recipes/AssemblerRecipes.java` inside the `getRecipes()` method and only changes how ingredient lists are transformed for NEI.

### Testing
- Ran `git diff --check` to validate whitespace and simple diffs (passed).
- Ran a source assertion script to verify the new NEI ingredient guards are present in `AssemblerRecipes.java` (passed).
- Attempted to run `./gradlew compileJava`, but the build was blocked by the environment: Gradle 4.4.1 requires Java 8 while the environment available JDKs were newer, and installing Java 8 via `mise` failed due to an outbound proxy error (compile could not be completed in CI environment).
- Attempted a compile with `JAVA_HOME` set to an available Java install (Java 11) but Gradle still failed to determine a compatible version (compile not completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23b93774948323909c9080f25bb6cd)