### PR TITLE
Sanitize HBM NEI recipes against null stacks

### DIFF
--- a/src/main/java/com/hbm/handler/nei/AlloyFurnaceRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/AlloyFurnaceRecipeHandler.java
@@ -19,7 +19,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class AlloyFurnaceRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class AlloyFurnaceRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	public static ArrayList<Fuel> fuels;
 
@@ -41,14 +41,14 @@ public class AlloyFurnaceRecipeHandler extends TemplateRecipeHandler implements 
 		PositionedStack result;
 
 		public SmeltingSet(List<ItemStack> list, List<ItemStack> list2, ItemStack result) {
-			this.input1 = new PositionedStack(list, 75, 7);
-			this.input2 = new PositionedStack(list2, 75, 43);
-			this.result = new PositionedStack(result, 129, 25);
+			this.input1 = NEISafe.positionedStack(list, 75, 7);
+			this.input2 = NEISafe.positionedStack(list2, 75, 43);
+			this.result = NEISafe.positionedStack(result, 129, 25);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] { input1, input2 }));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] { input1, input2 }));
 		}
 
 		@Override
@@ -65,7 +65,7 @@ public class AlloyFurnaceRecipeHandler extends TemplateRecipeHandler implements 
 	public static class Fuel {
 		public Fuel(ItemStack ingred) {
 
-			this.stack = new PositionedStack(ingred, 3, 25, false);
+			this.stack = NEISafe.positionedStack(ingred, 3, 25, false);
 		}
 
 		public PositionedStack stack;

--- a/src/main/java/com/hbm/handler/nei/AnvilRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/AnvilRecipeHandler.java
@@ -26,7 +26,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
-public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class AnvilRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -56,7 +56,7 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 	public LinkedList<Class<? extends GuiContainer>> guiGui = new LinkedList<Class<? extends GuiContainer>>();
 
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
-		
+
 		List<PositionedStack> input = new ArrayList();
 		List<PositionedStack> output = new ArrayList();
 		PositionedStack anvil;
@@ -74,7 +74,7 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 			int outOY = 0;
 			int anvX = 0;
 			int anvY = 31;
-			
+
 			if(in.size() == 1 && out.size() == 1) {
 				shape = OverlayType.SMITHING;
 				inOX = 48;
@@ -108,28 +108,28 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 				outOY = 6;
 				anvX = 75;
 			}
-			
+
 			for(int i = 0; i < in.size(); i++) {
-				this.input.add(new PositionedStack(in.get(i), inOX + 18 * (i % inLine), inOY + 18 * (i / inLine)));
+				this.input.add(NEISafe.positionedStack(in.get(i), inOX + 18 * (i % inLine), inOY + 18 * (i / inLine)));
 			}
-			
+
 			for(int i = 0; i < out.size(); i++) {
-				this.output.add(new PositionedStack(out.get(i), outOX + 18 * (i % outLine), outOY + 18 * (i / outLine)));
+				this.output.add(NEISafe.positionedStack(out.get(i), outOX + 18 * (i % outLine), outOY + 18 * (i / outLine)));
 			}
-			
-			this.anvil = new PositionedStack(NTMAnvil.getAnvilsFromTier(tier), anvX, anvY);
-			
+
+			this.anvil = NEISafe.positionedStack(NTMAnvil.getAnvilsFromTier(tier), anvX, anvY);
+
 			this.tier = tier;
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, input);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, input);
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return output.get(0);
+			return NEISafe.firstValid(output);
 		}
 
 		@Override
@@ -137,7 +137,7 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 			List<PositionedStack> other = new ArrayList();
 			other.addAll(output);
 			other.add(anvil);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -148,10 +148,10 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmAnvil")) {
 			List<AnvilConstructionRecipe> recipes = AnvilRecipes.getConstruction();
-			
+
 			for(AnvilConstructionRecipe recipe : recipes) {
 				this.addRecipeToList(recipe);
 			}
@@ -164,9 +164,9 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 	public void loadCraftingRecipes(ItemStack result) {
 
 		List<AnvilConstructionRecipe> recipes = AnvilRecipes.getConstruction();
-		
+
 		for(AnvilConstructionRecipe recipe : recipes) {
-			
+
 			for(AnvilOutput out : recipe.output) {
 				if(NEIServerUtils.areStacksSameTypeCrafting(out.stack, result)) {
 					this.addRecipeToList(recipe);
@@ -178,7 +178,7 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmAnvil")) {
 			loadCraftingRecipes("ntmAnvil", new Object[0]);
 		} else {
@@ -190,12 +190,12 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 	public void loadUsageRecipes(ItemStack ingredient) {
 
 		List<AnvilConstructionRecipe> recipes = AnvilRecipes.getConstruction();
-		
+
 		for(AnvilConstructionRecipe recipe : recipes) {
-			
+
 			outer:
 			for(AStack in : recipe.input) {
-				
+
 				List<ItemStack> stacks = in.extractForNEI();
 				for(ItemStack stack : stacks) {
 					if(NEIServerUtils.areStacksSameTypeCrafting(stack, ingredient)) {
@@ -206,38 +206,39 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 			}
 		}
 	}
-	
+
 	private void addRecipeToList(AnvilConstructionRecipe recipe) {
-		
+
 		List<Object> ins = new ArrayList();
 		for(AStack input : recipe.input) {
 			ins.add(input.extractForNEI());
 		}
-		
+
 		List<Object> outs = new ArrayList();
 		for(AnvilOutput output : recipe.output) {
-			
-			ItemStack stack = output.stack.copy();
+
+			ItemStack stack = output == null ? null : NEISafe.copy(output.stack);
+			if(stack == null) continue;
 			if(output.chance != 1) {
 				ItemStackUtil.addTooltipToStack(stack, EnumChatFormatting.RED + "" + (((int)(output.chance * 1000)) / 10D) + "%");
 			}
-			
+
 			outs.add(stack);
 		}
-		
+
 		this.arecipes.add(new RecipeSet(ins, outs, recipe.tierLower));
 	}
 
 	@Override
 	public void loadTransferRects() {
-		
+
 		//hey asshole, stop nulling my fucking lists
 		transferRectsGui = new LinkedList<RecipeTransferRect>();
 		guiGui = new LinkedList<Class<? extends GuiContainer>>();
 
 		transferRectsGui.add(new RecipeTransferRect(new Rectangle(11, 42, 36, 18), "ntmAnvil"));
 		transferRectsGui.add(new RecipeTransferRect(new Rectangle(65, 42, 36, 18), "ntmAnvil"));
-		
+
 		guiGui.add(GUIAnvil.class);
 		RecipeTransferRectHandler.registerRectsToGuis(guiGui, transferRectsGui);
 	}
@@ -250,9 +251,9 @@ public class AnvilRecipeHandler extends TemplateRecipeHandler implements ICompat
 	@Override
 	public void drawBackground(int recipe) {
 		super.drawBackground(recipe);
-		
+
 		RecipeSet set = (RecipeSet) this.arecipes.get(recipe);
-		
+
 		switch(set.shape) {
 		case NONE:
 			drawTexturedModalRect(2, 5, 5, 87, 72, 54);			//in

--- a/src/main/java/com/hbm/handler/nei/AssemblerRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/AssemblerRecipeHandler.java
@@ -21,8 +21,8 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
-	
+public class AssemblerRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
+
     public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
     public LinkedList<RecipeTransferRect> transferRectsGui = new LinkedList<RecipeTransferRect>();
     public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
@@ -41,28 +41,28 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 	}
 
     public class SmeltingSet extends TemplateRecipeHandler.CachedRecipe {
-    	
+
 		List<PositionedStack> input;
         PositionedStack result;
-    	
+
         public SmeltingSet(List<Object> in, ItemStack result) {
-        	
-        	input = new ArrayList();
-        	
-        	ComparableStack comp = new ComparableStack(result);
-        	ItemStack template = ItemAssemblyTemplate.writeType(new ItemStack(ModItems.assembly_template), comp);
-        	
-        	for(int i = 0; i < Math.min(in.size(), 12); i++) {
-        		input.add(new PositionedStack(in.get(i), 30 + (i % 4) * 18, 6 + (i / 4) * 18));
-        	}
-            
-            input.add(new PositionedStack(template, 66 + 45, 6));
-            this.result = new PositionedStack(result, 138, 24);
+
+	input = new ArrayList();
+
+	ComparableStack comp = new ComparableStack(result);
+	ItemStack template = ItemAssemblyTemplate.writeType(new ItemStack(ModItems.assembly_template), comp);
+
+	for(int i = 0; i < Math.min(in.size(), 12); i++) {
+		input.add(NEISafe.positionedStack(in.get(i), 30 + (i % 4) * 18, 6 + (i / 4) * 18));
+	}
+
+            input.add(NEISafe.positionedStack(template, 66 + 45, 6));
+            this.result = NEISafe.positionedStack(result, 138, 24);
         }
 
         @Override
 		public List<PositionedStack> getIngredients() {
-            return getCycledIngredients(cycleticks / 48, input);
+            return NEISafe.getCycledIngredients(this, cycleticks / 48, input);
         }
 
         @Override
@@ -70,7 +70,7 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
             return result;
         }
     }
-    
+
 	@Override
 	public String getRecipeName() {
 		return "Assembly Machine";
@@ -80,14 +80,14 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 	public String getGuiTexture() {
 		return RefStrings.MODID + ":textures/gui/nei/gui_nei_assembler.png";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if ((outputId.equals("assembly")) && getClass() == AssemblerRecipeHandler.class) {
-			
+
 			Map<ItemStack, List<Object>> recipes = AssemblerRecipes.getRecipes();
-			
+
 			for (Map.Entry<ItemStack, List<Object>> recipe : recipes.entrySet()) {
 				this.arecipes.add(new SmeltingSet(recipe.getValue(), recipe.getKey()));
 			}
@@ -98,11 +98,11 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		Map<ItemStack, List<Object>> recipes = AssemblerRecipes.getRecipes();
-		
+
 		for (Map.Entry<ItemStack, List<Object>> recipe : recipes.entrySet()) {
-			
+
 			if (NEIServerUtils.areStacksSameTypeCrafting(recipe.getKey(), result))
 				this.arecipes.add(new SmeltingSet(recipe.getValue(), recipe.getKey()));
 		}
@@ -110,7 +110,7 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if ((inputId.equals("assembly")) && getClass() == AssemblerRecipeHandler.class) {
 			loadCraftingRecipes("assembly", new Object[0]);
 		} else {
@@ -120,20 +120,20 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		Map<ItemStack, List<Object>> recipes = AssemblerRecipes.getRecipes();
-		
+
 		for (Map.Entry<ItemStack, List<Object>> recipe : recipes.entrySet()) {
-			
+
 			for(Object o : recipe.getValue()) {
-				
+
 				if(o instanceof ItemStack && NEIServerUtils.areStacksSameTypeCrafting((ItemStack)o, ingredient)) {
 					this.arecipes.add(new SmeltingSet(recipe.getValue(), recipe.getKey()));
-					
+
 				} else if(o instanceof List) {
-					
+
 					for(Object obj : (List)o) {
-						
+
 						if(obj instanceof ItemStack && NEIServerUtils.areStacksSameTypeCrafting((ItemStack)obj, ingredient)) {
 							this.arecipes.add(new SmeltingSet(recipe.getValue(), recipe.getKey()));
 						}
@@ -145,9 +145,9 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
 
     @Override
     public Class<? extends GuiContainer> getGuiClass() {
-    	return null;
+	return null;
     }
-    
+
     @Override
     public void loadTransferRects() {
         transferRectsGui = new LinkedList<RecipeTransferRect>();
@@ -164,7 +164,7 @@ public class AssemblerRecipeHandler extends TemplateRecipeHandler implements ICo
     public void drawExtras(int recipe) {
 
         drawProgressBar(83 - (18 * 4) - 9 + 1, 6, 0, 86, 16, 18 * 3 - 2, 480, 7);
-        
+
         drawProgressBar(83 - 3 + 16 + 5, 5 + 18, 16, 86, 36, 18, 48, 0);
     }
 

--- a/src/main/java/com/hbm/handler/nei/BreederRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/BreederRecipeHandler.java
@@ -18,7 +18,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class BreederRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class BreederRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -37,15 +37,16 @@ public class BreederRecipeHandler extends TemplateRecipeHandler implements IComp
 		public int flux;
 
 		public BreedingSet(ItemStack input, ItemStack result, int flux) {
-			input.stackSize = 1;
-			this.input = new PositionedStack(input, 30, 24);
-			this.result = new PositionedStack(result, 120, 24);
+			input = NEISafe.copy(input);
+			if(input != null) input.stackSize = 1;
+			this.input = NEISafe.positionedStack(input, 30, 24);
+			this.result = NEISafe.positionedStack(result, 120, 24);
 			this.flux = flux;
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
 		}
 
 		@Override

--- a/src/main/java/com/hbm/handler/nei/ChemplantRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/ChemplantRecipeHandler.java
@@ -22,7 +22,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class ChemplantRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<RecipeTransferRect> transferRectsGui = new LinkedList<RecipeTransferRect>();
@@ -49,60 +49,62 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 		PositionedStack template;
 
 		public RecipeSet(ChemRecipe recipe) {
-			
+
 			for(int i = 0; i < recipe.inputs.length; i++) {
 				AStack in = recipe.inputs[i];
 				if(in == null) continue;
-				this.itemIn[i] = new PositionedStack(in.extractForNEI(), 30 + (i % 2) * 18, 24 + (i / 2) * 18);
+				this.itemIn[i] = NEISafe.positionedStack(in.extractForNEI(), 30 + (i % 2) * 18, 24 + (i / 2) * 18);
 			}
-			
+
 			for(int i = 0; i < recipe.inputFluids.length; i++) {
 				FluidStack in = recipe.inputFluids[i];
 				if(in == null) continue;
 				ItemStack drop = ItemFluidIcon.make(in);
-				this.fluidIn[i] = new PositionedStack(drop, 30 + (i % 2) * 18, 6);
+				this.fluidIn[i] = NEISafe.positionedStack(drop, 30 + (i % 2) * 18, 6);
 			}
-			
+
 			for(int i = 0; i < recipe.outputs.length; i++) {
 				ItemStack out = recipe.outputs[i];
 				if(out == null) continue;
-				this.itemOut[i] = new PositionedStack(out, 120 + (i % 2) * 18, 24 + (i / 2) * 18);
+				this.itemOut[i] = NEISafe.positionedStack(out, 120 + (i % 2) * 18, 24 + (i / 2) * 18);
 			}
-			
+
 			for(int i = 0; i < recipe.outputFluids.length; i++) {
 				FluidStack out = recipe.outputFluids[i];
 				if(out == null) continue;
 				ItemStack drop = ItemFluidIcon.make(out);
-				this.fluidOut[i] = new PositionedStack(drop, 120 + (i % 2) * 18, 6);
+				this.fluidOut[i] = NEISafe.positionedStack(drop, 120 + (i % 2) * 18, 6);
 			}
-			
-			this.template = new PositionedStack(new ItemStack(ModItems.chemistry_template, 1, recipe.getId()), 84, 6);
+
+			this.template = NEISafe.positionedStack(new ItemStack(ModItems.chemistry_template, 1, recipe.getId()), 84, 6);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
 			List<PositionedStack> stacks = new ArrayList<PositionedStack>();
-			
+
 			for(PositionedStack stack : itemIn) if(stack != null) stacks.add(stack);
 			for(PositionedStack stack : fluidIn) if(stack != null) stacks.add(stack);
 			stacks.add(template);
-			
-			return getCycledIngredients(cycleticks / 20, stacks);
+
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, stacks);
 		}
 
 		@Override
 		public List<PositionedStack> getOtherStacks() {
 			List<PositionedStack> stacks = new ArrayList<PositionedStack>();
-			
+
 			for(PositionedStack stack : itemOut) if(stack != null) stacks.add(stack);
 			for(PositionedStack stack : fluidOut) if(stack != null) stacks.add(stack);
 			stacks.add(template);
-			
-			return stacks;
+
+			return NEISafe.cleanPositionedList(stacks);
 		}
 
 		@Override
 		public PositionedStack getResult() {
+			for(PositionedStack stack : itemOut) if(NEISafe.isValid(stack)) return stack;
+			for(PositionedStack stack : fluidOut) if(NEISafe.isValid(stack)) return stack;
 			return null;
 		}
 	}
@@ -119,9 +121,9 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if((outputId.equals("chemistry")) && getClass() == ChemplantRecipeHandler.class) {
-			
+
 			for(ChemRecipe recipe : ChemplantRecipes.recipes) {
 				this.arecipes.add(new RecipeSet(recipe));
 			}
@@ -135,20 +137,20 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 
 		outer:
 		for(ChemRecipe recipe : ChemplantRecipes.recipes) {
-			
+
 			for(ItemStack out : recipe.outputs) {
-				
+
 				if(out != null && NEIServerUtils.areStacksSameTypeCrafting(result, out)) {
 					this.arecipes.add(new RecipeSet(recipe));
 					continue outer;
 				}
 			}
-			
+
 			for(FluidStack out : recipe.outputFluids) {
-				
+
 				if(out != null) {
 					ItemStack drop = ItemFluidIcon.make(out.type, out.fill);
-					
+
 					if(compareFluidStacks(result, drop)) {
 						this.arecipes.add(new RecipeSet(recipe));
 						continue outer;
@@ -172,12 +174,12 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 
 		outer:
 		for(ChemRecipe recipe : ChemplantRecipes.recipes) {
-			
+
 			for(AStack in : recipe.inputs) {
-				
+
 				if(in != null) {
 					List<ItemStack> stacks = in.extractForNEI();
-					
+
 					for(ItemStack stack : stacks) {
 						if(NEIServerUtils.areStacksSameTypeCrafting(ingredient, stack)) {
 							this.arecipes.add(new RecipeSet(recipe));
@@ -186,12 +188,12 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 					}
 				}
 			}
-			
+
 			for(FluidStack in : recipe.inputFluids) {
-				
+
 				if(in != null) {
 					ItemStack drop = ItemFluidIcon.make(in.type, in.fill);
-					
+
 					if(compareFluidStacks(ingredient, drop)) {
 						this.arecipes.add(new RecipeSet(recipe));
 						continue outer;
@@ -202,7 +204,7 @@ public class ChemplantRecipeHandler extends TemplateRecipeHandler implements ICo
 	}
 
 	private boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/handler/nei/CrucibleAlloyingHandler.java
+++ b/src/main/java/com/hbm/handler/nei/CrucibleAlloyingHandler.java
@@ -21,7 +21,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class CrucibleAlloyingHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
 		return new ItemStack[]{
@@ -31,45 +31,45 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 	public String getRecipeID() {
 		return "ntmCrucibleAlloying";
 	}
-	
+
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
-	
+
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
 
 		List<PositionedStack> inputs = new ArrayList();
 		PositionedStack template;
 		PositionedStack crucible;
 		List<PositionedStack> outputs = new ArrayList();
-		
+
 		public RecipeSet(CrucibleRecipe recipe) {
 			List<ItemStack> inputs = new ArrayList();
 			List<ItemStack> outputs = new ArrayList();
 			for(MaterialStack stack : recipe.input) inputs.add(ItemScraps.create(stack, true));
 			for(MaterialStack stack : recipe.output) outputs.add(ItemScraps.create(stack, true));
-			
-			this.template = new PositionedStack(new ItemStack(ModItems.crucible_template, 1, recipe.getId()), 75, 6);
-			this.crucible = new PositionedStack(new ItemStack(ModBlocks.machine_crucible), 75, 42);
-			
+
+			this.template = NEISafe.positionedStack(new ItemStack(ModItems.crucible_template, 1, recipe.getId()), 75, 6);
+			this.crucible = NEISafe.positionedStack(new ItemStack(ModBlocks.machine_crucible), 75, 42);
+
 			for(int i = 0; i < inputs.size(); i++) {
-				PositionedStack pos = new PositionedStack(inputs.get(i), 12 + (i % 3) * 18, 6 + (i / 3) * 18);
+				PositionedStack pos = NEISafe.positionedStack(inputs.get(i), 12 + (i % 3) * 18, 6 + (i / 3) * 18);
 				this.inputs.add(pos);
 			}
-			
+
 			for(int i = 0; i < outputs.size(); i++) {
-				PositionedStack pos = new PositionedStack(outputs.get(i), 102 + (i % 3) * 18, 6 + (i / 3) * 18);
+				PositionedStack pos = NEISafe.positionedStack(outputs.get(i), 102 + (i % 3) * 18, 6 + (i / 3) * 18);
 				this.outputs.add(pos);
 			}
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, inputs);
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return outputs.get(0);
+			return NEISafe.firstValid(outputs);
 		}
 
 		@Override
@@ -79,7 +79,7 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 			other.add(crucible);
 			other.add(template);
 			other.addAll(outputs);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -92,10 +92,10 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 	public String getGuiTexture() {
 		return RefStrings.MODID + ":textures/gui/nei/gui_nei_crucible.png";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmCrucibleAlloying")) {
 
 			for(CrucibleRecipe recipe : CrucibleRecipes.recipes) {
@@ -105,17 +105,17 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 			super.loadCraftingRecipes(outputId, results);
 		}
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		if(result.getItem() != ModItems.scraps)
 			return;
-		
+
 		NTMMaterial material = Mats.matById.get(result.getItemDamage());
 
 		for(CrucibleRecipe recipe : CrucibleRecipes.recipes) {
-			
+
 			for(MaterialStack stack : recipe.output) {
 				if(stack.material == material) {
 					this.arecipes.add(new RecipeSet(recipe));
@@ -124,27 +124,27 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmCrucibleAlloying")) {
 			loadCraftingRecipes("ntmCrucibleAlloying", new Object[0]);
 		} else {
 			super.loadUsageRecipes(inputId, ingredients);
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		if(ingredient.getItem() != ModItems.scraps)
 			return;
-		
+
 		NTMMaterial material = Mats.matById.get(ingredient.getItemDamage());
 
 		for(CrucibleRecipe recipe : CrucibleRecipes.recipes) {
-			
+
 			for(MaterialStack stack : recipe.input) {
 				if(stack.material == material) {
 					this.arecipes.add(new RecipeSet(recipe));
@@ -153,7 +153,7 @@ public class CrucibleAlloyingHandler extends TemplateRecipeHandler implements IC
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadTransferRects() {
 		transferRects.add(new RecipeTransferRect(new Rectangle(65, 23, 36, 18), "ntmCrucibleAlloying"));

--- a/src/main/java/com/hbm/handler/nei/CrucibleCastingHandler.java
+++ b/src/main/java/com/hbm/handler/nei/CrucibleCastingHandler.java
@@ -19,7 +19,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class CrucibleCastingHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -32,29 +32,32 @@ public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICo
 	public String getRecipeID() {
 		return "ntmCrucibleFoundry";
 	}
-	
+
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
-	
+
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
 
 		PositionedStack input;
 		PositionedStack mold;
 		PositionedStack basin;
 		PositionedStack output;
-		
+
 		public RecipeSet(ItemStack[] stacks) {
-			this.input = new PositionedStack(stacks[0].copy(), 48, 24);
-			this.mold = new PositionedStack(stacks[1].copy(), 75, 6);
-			this.basin = new PositionedStack(stacks[2].copy(), 75, 42);
+			this.input = NEISafe.positionedStack(NEISafe.copy(stacks != null && stacks.length > 0 ? stacks[0] : null), 48, 24);
+			this.mold = NEISafe.positionedStack(NEISafe.copy(stacks != null && stacks.length > 1 ? stacks[1] : null), 75, 6);
+			this.basin = NEISafe.positionedStack(NEISafe.copy(stacks != null && stacks.length > 2 ? stacks[2] : null), 75, 42);
 			//through reasons i cannot explain, stacks[3]'s stack size does not survive until this point.
-			ItemStack o = ItemMold.moldById.get(stacks[1].getItemDamage()).getOutput(Mats.matById.get(stacks[0].getItemDamage()));
-			this.output = new PositionedStack(o.copy(), 102, 24);
+			ItemStack o = null;
+			if(stacks != null && stacks.length > 1 && NEISafe.isValid(stacks[0]) && NEISafe.isValid(stacks[1]) && ItemMold.moldById.get(stacks[1].getItemDamage()) != null) {
+				o = ItemMold.moldById.get(stacks[1].getItemDamage()).getOutput(Mats.matById.get(stacks[0].getItemDamage()));
+			}
+			this.output = NEISafe.positionedStack(o, 102, 24);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, Arrays.asList(input, mold, basin));
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, Arrays.asList(input, mold, basin));
 		}
 
 		@Override
@@ -69,7 +72,7 @@ public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICo
 			other.add(mold);
 			other.add(basin);
 			other.add(output);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -82,12 +85,12 @@ public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICo
 	public String getGuiTexture() {
 		return RefStrings.MODID + ":textures/gui/nei/gui_nei_foundry.png";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmCrucibleFoundry")) {
-			
+
 			for(ItemStack[] recipe : CrucibleRecipes.getMoldRecipes()) {
 				this.arecipes.add(new RecipeSet(recipe));
 			}
@@ -95,32 +98,32 @@ public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICo
 			super.loadCraftingRecipes(outputId, results);
 		}
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		for(ItemStack[] recipe : CrucibleRecipes.getMoldRecipes()) {
 			if(NEIServerUtils.areStacksSameTypeCrafting(recipe[3], result)) {
 				this.arecipes.add(new RecipeSet(recipe));
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmCrucibleFoundry")) {
 			loadCraftingRecipes("ntmCrucibleFoundry", new Object[0]);
 		} else {
 			super.loadUsageRecipes(inputId, ingredients);
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		for(ItemStack[] recipe : CrucibleRecipes.getMoldRecipes()) {
-			
+
 			for(int i = 0; i < 3; i++) {
 				if(NEIServerUtils.areStacksSameTypeCrafting(recipe[i], ingredient)) {
 					this.arecipes.add(new RecipeSet(recipe));
@@ -129,7 +132,7 @@ public class CrucibleCastingHandler extends TemplateRecipeHandler implements ICo
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadTransferRects() {
 		transferRects.add(new RecipeTransferRect(new Rectangle(65, 23, 36, 18), "ntmCrucibleFoundry"));

--- a/src/main/java/com/hbm/handler/nei/CrucibleSmeltingHandler.java
+++ b/src/main/java/com/hbm/handler/nei/CrucibleSmeltingHandler.java
@@ -20,7 +20,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class CrucibleSmeltingHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -33,31 +33,31 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 	}
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
-	
+
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
 
 		PositionedStack input;
 		PositionedStack crucible;
 		List<PositionedStack> outputs = new ArrayList();
-		
+
 		public RecipeSet(AStack input, List<ItemStack> outputs) {
-			this.input = new PositionedStack(input.extractForNEI(), 48, 24);
-			this.crucible = new PositionedStack(new ItemStack(ModBlocks.machine_crucible), 75, 42);
-			
+			this.input = NEISafe.positionedStack(input.extractForNEI(), 48, 24);
+			this.crucible = NEISafe.positionedStack(new ItemStack(ModBlocks.machine_crucible), 75, 42);
+
 			for(int i = 0; i < outputs.size(); i++) {
-				PositionedStack pos = new PositionedStack(outputs.get(i), 102 + (i % 3) * 18, 6 + (i / 3) * 18);
+				PositionedStack pos = NEISafe.positionedStack(outputs.get(i), 102 + (i % 3) * 18, 6 + (i / 3) * 18);
 				this.outputs.add(pos);
 			}
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, Arrays.asList(input));
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, Arrays.asList(input));
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return outputs.get(0);
+			return NEISafe.firstValid(outputs);
 		}
 
 		@Override
@@ -66,7 +66,7 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 			other.add(input);
 			other.add(crucible);
 			other.addAll(outputs);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -79,14 +79,14 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 	public String getGuiTexture() {
 		return RefStrings.MODID + ":textures/gui/nei/gui_nei_crucible_smelting.png";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmCrucibleSmelting")) {
-			
+
 			HashMap<AStack, List<ItemStack>> smelting = CrucibleRecipes.getSmeltingRecipes();
-			
+
 			for(Entry<AStack, List<ItemStack>> recipe : smelting.entrySet()) {
 				this.arecipes.add(new RecipeSet(recipe.getKey(), recipe.getValue()));
 			}
@@ -94,15 +94,15 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 			super.loadCraftingRecipes(outputId, results);
 		}
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
 		HashMap<AStack, List<ItemStack>> smelting = CrucibleRecipes.getSmeltingRecipes();
 
 		for(Entry<AStack, List<ItemStack>> recipe : smelting.entrySet()) {
-			
+
 			for(ItemStack stack : recipe.getValue()) {
-				
+
 				if(NEIServerUtils.areStacksSameTypeCrafting(stack, result)) {
 					this.arecipes.add(new RecipeSet(recipe.getKey(), recipe.getValue()));
 					break;
@@ -110,17 +110,17 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmCrucibleSmelting")) {
 			loadCraftingRecipes("ntmCrucibleSmelting", new Object[0]);
 		} else {
 			super.loadUsageRecipes(inputId, ingredients);
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
 		HashMap<AStack, List<ItemStack>> smelting = CrucibleRecipes.getSmeltingRecipes();
@@ -131,7 +131,7 @@ public class CrucibleSmeltingHandler extends TemplateRecipeHandler implements IC
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadTransferRects() {
 		transferRects.add(new RecipeTransferRect(new Rectangle(65, 23, 36, 18), "ntmCrucibleSmelting"));

--- a/src/main/java/com/hbm/handler/nei/CustomMachineHandler.java
+++ b/src/main/java/com/hbm/handler/nei/CustomMachineHandler.java
@@ -25,7 +25,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
-public class CustomMachineHandler extends TemplateRecipeHandler {
+public class CustomMachineHandler extends SafeTemplateRecipeHandler {
 
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
@@ -61,47 +61,49 @@ public class CustomMachineHandler extends TemplateRecipeHandler {
 
 		public RecipeSet(CustomMachineRecipe recipe) {
 
-			for(int i = 0; i < 3; i++) if(recipe.inputFluids.length > i) inputs.add(new PositionedStack(ItemFluidIcon.make(recipe.inputFluids[i]), 12 + i * 18, 6));
-			for(int i = 0; i < 3; i++) if(recipe.inputItems.length > i) inputs.add(new PositionedStack(recipe.inputItems[i].extractForNEI(), 12 + i * 18, 24));
-			for(int i = 3; i < 6; i++) if(recipe.inputItems.length > i) inputs.add(new PositionedStack(recipe.inputItems[i].extractForNEI(), 12 + (i - 3) * 18, 42));
+			for(int i = 0; i < 3; i++) if(recipe.inputFluids.length > i) inputs.add(NEISafe.positionedStack(ItemFluidIcon.make(recipe.inputFluids[i]), 12 + i * 18, 6));
+			for(int i = 0; i < 3; i++) if(recipe.inputItems.length > i) inputs.add(NEISafe.positionedStack(recipe.inputItems[i].extractForNEI(), 12 + i * 18, 24));
+			for(int i = 3; i < 6; i++) if(recipe.inputItems.length > i) inputs.add(NEISafe.positionedStack(recipe.inputItems[i].extractForNEI(), 12 + (i - 3) * 18, 42));
 
-			for(int i = 0; i < 3; i++) if(recipe.outputFluids.length > i) outputs.add(new PositionedStack(ItemFluidIcon.make(recipe.outputFluids[i]), 102 + i * 18, 6));
+			for(int i = 0; i < 3; i++) if(recipe.outputFluids.length > i) outputs.add(NEISafe.positionedStack(ItemFluidIcon.make(recipe.outputFluids[i]), 102 + i * 18, 6));
 
 			for(int i = 0; i < 3; i++) if(recipe.outputItems.length > i) {
 				Pair<ItemStack, Float> pair = recipe.outputItems[i];
-				ItemStack out = pair.getKey().copy();
+				ItemStack out = pair == null ? null : NEISafe.copy(pair.getKey());
+				if(out == null) continue;
 				if(pair.getValue() != 1) {
 					ItemStackUtil.addTooltipToStack(out, EnumChatFormatting.RED + "" + (((int)(pair.getValue() * 1000)) / 10D) + "%");
 				}
-				outputs.add(new PositionedStack(out, 102 + i * 18, 24));
+				outputs.add(NEISafe.positionedStack(out, 102 + i * 18, 24));
 			}
 
 			for(int i = 3; i < 6; i++) if(recipe.outputItems.length > i) {
 				Pair<ItemStack, Float> pair = recipe.outputItems[i];
-				ItemStack out = pair.getKey().copy();
+				ItemStack out = pair == null ? null : NEISafe.copy(pair.getKey());
+				if(out == null) continue;
 				if(pair.getValue() != 1) {
 					ItemStackUtil.addTooltipToStack(out, EnumChatFormatting.RED + "" + (((int)(pair.getValue() * 1000)) / 10D) + "%");
 				}
-				outputs.add(new PositionedStack(out, 102 + (i - 3) * 18, 42));
+				outputs.add(NEISafe.positionedStack(out, 102 + (i - 3) * 18, 42));
 			}
-			
+
 			this.pollutionType = recipe.pollutionType;
 			this.pollutionAmount = recipe.pollutionAmount;
 			this.radiationAmount = recipe.radiationAmount;
 			if(conf.fluxMode) this.flux = recipe.flux;
 			if(conf.maxHeat > 0 && recipe.heat > 0) this.heat = recipe.heat;
-			
-			this.machine = new PositionedStack(new ItemStack(ModBlocks.custom_machine, 1, 100 + CustomMachineConfigJSON.niceList.indexOf(conf)), 75, 42);
+
+			this.machine = NEISafe.positionedStack(new ItemStack(ModBlocks.custom_machine, 1, 100 + CustomMachineConfigJSON.niceList.indexOf(conf)), 75, 42);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, inputs);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, inputs);
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return outputs.get(0);
+			return NEISafe.firstValid(outputs);
 		}
 
 		@Override
@@ -110,7 +112,7 @@ public class CustomMachineHandler extends TemplateRecipeHandler {
 			other.addAll(inputs);
 			other.add(machine);
 			other.addAll(outputs);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -206,7 +208,7 @@ public class CustomMachineHandler extends TemplateRecipeHandler {
 	}
 
 	public static boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/handler/nei/CyclotronRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/CyclotronRecipeHandler.java
@@ -18,7 +18,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class CyclotronRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class CyclotronRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
 		return new ItemStack[]{
@@ -36,21 +36,23 @@ public class CyclotronRecipeHandler extends TemplateRecipeHandler implements ICo
 
     public class SmeltingSet extends TemplateRecipeHandler.CachedRecipe
     {
-    	PositionedStack input1;
+	PositionedStack input1;
 		PositionedStack input2;
         PositionedStack result;
 
         public SmeltingSet(ItemStack input1, ItemStack input2, ItemStack result) {
-        	input1.stackSize = 1;
-        	input2.stackSize = 1;
-            this.input1 = new PositionedStack(input1, 66 - 45, 6 + 18);
-            this.input2 = new PositionedStack(input2, 66 + 9, 42 - 18);
-            this.result = new PositionedStack(result, 129, 24);
+	input1 = NEISafe.copy(input1);
+	input2 = NEISafe.copy(input2);
+	if(input1 != null) input1.stackSize = 1;
+	if(input2 != null) input2.stackSize = 1;
+            this.input1 = NEISafe.positionedStack(input1, 66 - 45, 6 + 18);
+            this.input2 = NEISafe.positionedStack(input2, 66 + 9, 42 - 18);
+            this.result = NEISafe.positionedStack(result, 129, 24);
         }
 
         @Override
 		public List<PositionedStack> getIngredients() {
-            return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] {input1, input2}));
+            return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] {input1, input2}));
         }
 
         @Override
@@ -127,7 +129,7 @@ public class CyclotronRecipeHandler extends TemplateRecipeHandler implements ICo
     @Override
     public Class<? extends GuiContainer> getGuiClass() {
         //return GUITestDiFurnace.class;
-    	return null;
+	return null;
     }
 
     @Override

--- a/src/main/java/com/hbm/handler/nei/FluidRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/FluidRecipeHandler.java
@@ -16,7 +16,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class FluidRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class FluidRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
 		return new ItemStack[]{
@@ -36,18 +36,19 @@ public class FluidRecipeHandler extends TemplateRecipeHandler implements ICompat
 
     public class SmeltingSet extends TemplateRecipeHandler.CachedRecipe
     {
-    	PositionedStack input;
+	PositionedStack input;
         PositionedStack result;
 
         public SmeltingSet(ItemStack input, ItemStack result) {
-        	input.stackSize = 1;
-            this.input = new PositionedStack(input, 83 - 27 - 18 + 1, 5 + 18 + 1);
-            this.result = new PositionedStack(result, 83 + 27 + 18 + 1 - 18, 5 + 18 + 1);
+	input = NEISafe.copy(input);
+	if(input != null) input.stackSize = 1;
+            this.input = NEISafe.positionedStack(input, 83 - 27 - 18 + 1, 5 + 18 + 1);
+            this.result = NEISafe.positionedStack(result, 83 + 27 + 18 + 1 - 18, 5 + 18 + 1);
         }
 
         @Override
 		public List<PositionedStack> getIngredients() {
-            return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] {input}));
+            return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] {input}));
         }
 
         @Override
@@ -106,13 +107,13 @@ public class FluidRecipeHandler extends TemplateRecipeHandler implements ICompat
 	}
 
 	private boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
 
     @Override
     public Class<? extends GuiContainer> getGuiClass() {
         //return GUIMachineShredder.class;
-    	return null;
+	return null;
     }
 
     @Override

--- a/src/main/java/com/hbm/handler/nei/FusionRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/FusionRecipeHandler.java
@@ -18,7 +18,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class FusionRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -35,19 +35,19 @@ public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompa
     public LinkedList<Class<? extends GuiContainer>> guiGui = new LinkedList<Class<? extends GuiContainer>>();
 
     public class SmeltingSet extends TemplateRecipeHandler.CachedRecipe {
-    	
+
 		PositionedStack input;
         PositionedStack result;
-    	
+
         public SmeltingSet(ItemStack in, ItemStack out) {
-        	
-        	this.input = new PositionedStack(in, 30, 24);
-            this.result = new PositionedStack(out, 120, 24);
+
+	this.input = NEISafe.positionedStack(in, 30, 24);
+            this.result = NEISafe.positionedStack(out, 120, 24);
         }
 
         @Override
 		public List<PositionedStack> getIngredients() {
-        	
+
             return new ArrayList() {{ add(input); }};
         }
 
@@ -56,23 +56,23 @@ public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompa
             return result;
         }
     }
-    
+
 	@Override
 	public String getRecipeName() {
 		return "Fusion Reactor";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("fusion") && getClass() == FusionRecipeHandler.class) {
-			
+
 			Map<ItemStack, ItemStack> recipes = FusionRecipes.getRecipes();
-			
+
 			for(Map.Entry<ItemStack, ItemStack> recipe : recipes.entrySet()) {
 				this.arecipes.add(new SmeltingSet(recipe.getKey(), recipe.getValue()));
 			}
-			
+
 		} else {
 			super.loadCraftingRecipes(outputId, results);
 		}
@@ -80,11 +80,11 @@ public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompa
 
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		Map<ItemStack, ItemStack> recipes = FusionRecipes.getRecipes();
-		
+
 		for(Map.Entry<ItemStack, ItemStack> recipe : recipes.entrySet()) {
-			
+
 			if(NEIServerUtils.areStacksSameTypeCrafting(recipe.getValue(), result)) {
 				this.arecipes.add(new SmeltingSet(recipe.getKey(), recipe.getValue()));
 			}
@@ -93,7 +93,7 @@ public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompa
 
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("fusion") && getClass() == FusionRecipeHandler.class) {
 			loadCraftingRecipes("fusion", new Object[0]);
 		} else {
@@ -103,17 +103,17 @@ public class FusionRecipeHandler extends TemplateRecipeHandler implements ICompa
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		Map<ItemStack, ItemStack> recipes = FusionRecipes.getRecipes();
-		
+
 		for(Map.Entry<ItemStack, ItemStack> recipe : recipes.entrySet()) {
-			
+
 			if(NEIServerUtils.areStacksSameTypeCrafting(recipe.getKey(), ingredient)) {
 				this.arecipes.add(new SmeltingSet(recipe.getKey(), recipe.getValue()));
 			}
 		}
 	}
-    
+
     @Override
     public void loadTransferRects() {
         transferRectsGui = new LinkedList<RecipeTransferRect>();

--- a/src/main/java/com/hbm/handler/nei/GasCentrifugeRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/GasCentrifugeRecipeHandler.java
@@ -24,7 +24,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class GasCentrifugeRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class GasCentrifugeRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
 		return new ItemStack[]{
@@ -43,19 +43,20 @@ public class GasCentrifugeRecipeHandler extends TemplateRecipeHandler implements
 		int centNumber;
 
 		public SmeltingSet(ItemStack input, ItemStack[] results, boolean isHighSpeed, int centNumber) {
-			input.stackSize = 1;
-			this.input = new PositionedStack(input, 52 - 5, 35 - 11);
+			input = NEISafe.copy(input);
+			if(input != null) input.stackSize = 1;
+			this.input = NEISafe.positionedStack(input, 52 - 5, 35 - 11);
 			this.isHighSpeed = isHighSpeed;
 			this.centNumber = centNumber;
-			
+
 			for(byte i = 0; i < results.length; i++) {
-				this.output.add(new PositionedStack(results[i], i % 2 == 0 ? 134 - 5 : 152 - 5, i < 2 ? 26 - 11 : 44 - 11 ));
+				this.output.add(NEISafe.positionedStack(results[i], i % 2 == 0 ? 134 - 5 : 152 - 5, i < 2 ? 26 - 11 : 44 - 11 ));
 			}
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
 		}
 
 		@Override
@@ -63,19 +64,19 @@ public class GasCentrifugeRecipeHandler extends TemplateRecipeHandler implements
 			List<PositionedStack> stacks = new ArrayList<PositionedStack>();
 			stacks.add(fuels.get((cycleticks / 48) % fuels.size()).stack);
 			stacks.addAll(output);
-			return stacks;
+			return NEISafe.cleanPositionedList(stacks);
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return output.get(0);
+			return NEISafe.firstValid(output);
 		}
 	}
 
 	public static class Fuel {
 		public Fuel(ItemStack ingred) {
 
-			this.stack = new PositionedStack(ingred, 3, 42, false);
+			this.stack = NEISafe.positionedStack(ingred, 3, 42, false);
 		}
 
 		public PositionedStack stack;
@@ -142,23 +143,23 @@ public class GasCentrifugeRecipeHandler extends TemplateRecipeHandler implements
 	}
 
 	private boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
 
 	@Override
 	public void drawExtras(int recipe) {
 		drawProgressBar(3, 51 - 45, 176, 0, 16, 34, 480, 7);
-		
+
 		SmeltingSet set = (SmeltingSet) this.arecipes.get(recipe);
-		
+
 		drawProgressBar(79 - 5, 28 - 11, 208, 0, 44, 37, set.isHighSpeed ? 150 - 70 : 150, 0);
-		
+
 		FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
-		
+
 		String centrifuges = set.centNumber + " G. Cents";
 		fontRenderer.drawString(centrifuges, (50 - fontRenderer.getStringWidth(centrifuges) / 2), 21 - 11, 65280);
 	}
-	
+
 	public LinkedList<RecipeTransferRect> transferRectsRec = new LinkedList<RecipeTransferRect>();
 	public LinkedList<RecipeTransferRect> transferRectsGui = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
@@ -168,21 +169,21 @@ public class GasCentrifugeRecipeHandler extends TemplateRecipeHandler implements
 	public void loadTransferRects() {
 		transferRectsGui = new LinkedList<RecipeTransferRect>();
 		guiGui = new LinkedList<Class<? extends GuiContainer>>();
-		
+
 		transferRects.add(new RecipeTransferRect(new Rectangle(79 - 5, 26 - 11, 44, 40), "gascentprocessing"));
 		transferRectsGui.add(new RecipeTransferRect(new Rectangle(70 - 5, 36 - 11, 36, 12), "gascentprocessing"));
-		
+
 		guiGui.add(GUIMachineGasCent.class);
 		RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
 		RecipeTransferRectHandler.registerRectsToGuis(guiGui, transferRectsGui);
 	}
-	
+
 	@Override
 	public void drawBackground(int recipe) {
 		super.drawBackground(recipe);
-		
+
 		SmeltingSet set = (SmeltingSet) this.arecipes.get(recipe);
-		
+
 		if(set.isHighSpeed)
 			drawTexturedModalRect(30 - 5, 35 - 11, 192, 0, 16, 16);
 	}

--- a/src/main/java/com/hbm/handler/nei/HadronRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/HadronRecipeHandler.java
@@ -23,7 +23,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class HadronRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class HadronRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -50,22 +50,22 @@ public class HadronRecipeHandler extends TemplateRecipeHandler implements ICompa
 
 		public RecipeSet(HadronRecipe recipe) {
 
-			this.input1 = new PositionedStack(recipe.in1.toStack(), 12, 24);
-			this.input2 = new PositionedStack(recipe.in2.toStack(), 30, 24);
-			this.output1 = new PositionedStack(recipe.out1, 84, 24);
-			this.output2 = new PositionedStack(recipe.out2, 102, 24);
+			this.input1 = NEISafe.positionedStack(recipe.in1.toStack(), 12, 24);
+			this.input2 = NEISafe.positionedStack(recipe.in2.toStack(), 30, 24);
+			this.output1 = NEISafe.positionedStack(recipe.out1, 84, 24);
+			this.output2 = NEISafe.positionedStack(recipe.out2, 102, 24);
 			this.momentum = recipe.momentum;
 			this.analysisOnly = recipe.analysisOnly;
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return Arrays.asList(new PositionedStack[] { input1, input2 });
+			return NEISafe.positionedList(input1, input2);
 		}
 
 		@Override
 		public List<PositionedStack> getOtherStacks() {
-			return Arrays.asList(new PositionedStack[] { output1, output2 });
+			return NEISafe.positionedList(output1, output2);
 		}
 
 		@Override

--- a/src/main/java/com/hbm/handler/nei/NEISafe.java
+++ b/src/main/java/com/hbm/handler/nei/NEISafe.java
@@ -1,0 +1,220 @@
+package com.hbm.handler.nei;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.hbm.main.MainRegistry;
+
+import codechicken.nei.PositionedStack;
+import codechicken.nei.recipe.TemplateRecipeHandler;
+import net.minecraft.item.ItemStack;
+
+/** Shared null-safety helpers for HBM NEI recipe handlers. */
+public final class NEISafe {
+
+	private static final Set<String> LOGGED = new HashSet<String>();
+
+	private NEISafe() { }
+
+	public static boolean isValid(ItemStack stack) {
+		return stack != null && stack.getItem() != null && stack.stackSize > 0;
+	}
+
+	public static ItemStack copy(ItemStack stack) {
+		return isValid(stack) ? stack.copy() : null;
+	}
+
+	public static ItemStack[] copyValid(ItemStack[] stacks) {
+		if(stacks == null || stacks.length == 0) return null;
+		List<ItemStack> valid = new ArrayList<ItemStack>();
+		for(ItemStack stack : stacks) {
+			ItemStack copy = copy(stack);
+			if(copy != null) valid.add(copy);
+		}
+		return valid.isEmpty() ? null : valid.toArray(new ItemStack[valid.size()]);
+	}
+
+	public static List<ItemStack> copyValid(Collection<ItemStack> stacks) {
+		if(stacks == null || stacks.isEmpty()) return Collections.emptyList();
+		List<ItemStack> valid = new ArrayList<ItemStack>();
+		for(ItemStack stack : stacks) {
+			ItemStack copy = copy(stack);
+			if(copy != null) valid.add(copy);
+		}
+		return valid;
+	}
+
+	public static ItemStack[][] copyValid2D(ItemStack[][] stacks) {
+		if(stacks == null || stacks.length == 0) return null;
+		List<ItemStack[]> valid = new ArrayList<ItemStack[]>();
+		for(ItemStack[] stack : stacks) {
+			ItemStack[] copy = copyValid(stack);
+			if(copy != null) valid.add(copy);
+		}
+		return valid.isEmpty() ? null : valid.toArray(new ItemStack[valid.size()][]);
+	}
+
+	public static PositionedStack positionedStack(Object object, int x, int y) {
+		return positionedStack(object, x, y, true);
+	}
+
+	public static PositionedStack positionedStack(Object object, int x, int y, boolean genPermutations) {
+		Object safe = safeIngredientObject(object);
+		if(safe == null) return null;
+		try {
+			PositionedStack stack = new PositionedStack(safe, x, y, genPermutations);
+			return isValid(stack) ? stack : null;
+		} catch(Throwable t) {
+			logSkip("PositionedStack", "Failed to create positioned stack from " + describe(object), t);
+			return null;
+		}
+	}
+
+	private static Object safeIngredientObject(Object object) {
+		if(object instanceof ItemStack) return copy((ItemStack)object);
+		if(object instanceof ItemStack[]) return copyValid((ItemStack[])object);
+		if(object instanceof Collection) return copyValid((Collection<ItemStack>)object);
+		return object;
+	}
+
+	public static List<PositionedStack> positionedList(PositionedStack... stacks) {
+		List<PositionedStack> list = new ArrayList<PositionedStack>();
+		if(stacks == null) return list;
+		for(PositionedStack stack : stacks) if(isValid(stack)) list.add(stack);
+		return list;
+	}
+
+	public static List<PositionedStack> cleanPositionedList(Collection<PositionedStack> stacks) {
+		List<PositionedStack> list = new ArrayList<PositionedStack>();
+		if(stacks == null) return list;
+		for(PositionedStack stack : stacks) if(isValid(stack)) list.add(stack);
+		return list;
+	}
+
+	public static PositionedStack firstValid(Collection<PositionedStack> stacks) {
+		if(stacks == null) return null;
+		for(PositionedStack stack : stacks) if(isValid(stack)) return stack;
+		return null;
+	}
+
+	public static List<PositionedStack> getCycledIngredients(TemplateRecipeHandler.CachedRecipe recipe, int cycle, Collection<PositionedStack> stacks) {
+		List<PositionedStack> list = cleanPositionedList(stacks);
+		for(PositionedStack stack : list) setPermutation(stack, cycle);
+		return list;
+	}
+
+	public static boolean isValid(PositionedStack stack) {
+		if(stack == null) return false;
+		ItemStack[] items = getItems(stack);
+		if(items == null || items.length == 0) return false;
+		List<ItemStack> valid = new ArrayList<ItemStack>();
+		for(ItemStack item : items) {
+			ItemStack copy = copy(item);
+			if(copy != null) valid.add(copy);
+		}
+		if(valid.isEmpty()) return false;
+		setItems(stack, valid.toArray(new ItemStack[valid.size()]));
+		return true;
+	}
+
+	public static boolean isSafeRecipe(TemplateRecipeHandler handler, TemplateRecipeHandler.CachedRecipe recipe, String source) {
+		if(recipe == null) {
+			logSkip(handler, source, "null cached recipe", null);
+			return false;
+		}
+		try {
+			PositionedStack result = recipe.getResult();
+			if(!isValid(result)) {
+				logSkip(handler, source, "missing or invalid main output in " + recipe.getClass().getName(), null);
+				return false;
+			}
+			List<PositionedStack> ingredients = cleanPositionedList(recipe.getIngredients());
+			if(ingredients.isEmpty()) {
+				PositionedStack ingredient = recipe.getIngredient();
+				if(isValid(ingredient)) ingredients.add(ingredient);
+			}
+			if(ingredients.isEmpty()) {
+				logSkip(handler, source, "missing or invalid required input in " + recipe.getClass().getName(), null);
+				return false;
+			}
+			recipe.getOtherStacks(); // optional stacks are sanitized by handler return helpers where present
+			return true;
+		} catch(Throwable t) {
+			logSkip(handler, source, "malformed cached recipe " + recipe.getClass().getName(), t);
+			return false;
+		}
+	}
+
+	public static ItemStack firstStack(PositionedStack stack) {
+		if(!isValid(stack)) return null;
+		ItemStack[] items = getItems(stack);
+		return items != null && items.length > 0 ? copy(items[0]) : null;
+	}
+
+	/** Development helper: validates currently cached NEI recipes without rendering them. */
+	public static void validateCachedRecipes(TemplateRecipeHandler handler) {
+		if(handler == null || handler.arecipes == null) return;
+		for(Object recipe : new ArrayList<Object>(handler.arecipes)) {
+			if(recipe instanceof TemplateRecipeHandler.CachedRecipe) {
+				isSafeRecipe(handler, (TemplateRecipeHandler.CachedRecipe) recipe, "dev validation");
+			} else {
+				logSkip(handler, "dev validation", "non-cached recipe entry " + describe(recipe), null);
+			}
+		}
+	}
+
+	private static ItemStack[] getItems(PositionedStack stack) {
+		try {
+			Field field = PositionedStack.class.getField("items");
+			return (ItemStack[]) field.get(stack);
+		} catch(Throwable ignored) { }
+		try {
+			Field field = PositionedStack.class.getDeclaredField("items");
+			field.setAccessible(true);
+			return (ItemStack[]) field.get(stack);
+		} catch(Throwable ignored) { }
+		try {
+			Field field = PositionedStack.class.getField("item");
+			Object item = field.get(stack);
+			if(item instanceof ItemStack) return new ItemStack[] {(ItemStack)item};
+		} catch(Throwable ignored) { }
+		return null;
+	}
+
+	private static void setItems(PositionedStack stack, ItemStack[] items) {
+		try {
+			Field field = PositionedStack.class.getField("items");
+			field.set(stack, items);
+		} catch(Throwable ignored) { }
+	}
+
+	private static void setPermutation(PositionedStack stack, int cycle) {
+		try {
+			PositionedStack.class.getMethod("setPermutationToRender", int.class).invoke(stack, cycle);
+		} catch(Throwable ignored) { }
+	}
+
+	private static void logSkip(TemplateRecipeHandler handler, String source, String reason, Throwable t) {
+		String name = handler == null ? "unknown" : handler.getClass().getSimpleName() + "/" + handler.getRecipeName();
+		logSkip(name, source + ": " + reason, t);
+	}
+
+	private static void logSkip(String name, String reason, Throwable t) {
+		String key = name + "|" + reason;
+		if(!LOGGED.add(key)) return;
+		if(t == null) {
+			MainRegistry.logger.warn("[NEI safety] Skipped broken recipe in " + name + ": " + reason);
+		} else {
+			MainRegistry.logger.warn("[NEI safety] Skipped broken recipe in " + name + ": " + reason + " (" + t.getClass().getSimpleName() + ": " + t.getMessage() + ")");
+		}
+	}
+
+	private static String describe(Object object) {
+		return object == null ? "null" : object.getClass().getName();
+	}
+}

--- a/src/main/java/com/hbm/handler/nei/NEIUniversalHandler.java
+++ b/src/main/java/com/hbm/handler/nei/NEIUniversalHandler.java
@@ -23,7 +23,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-public abstract class NEIUniversalHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public abstract class NEIUniversalHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -34,7 +34,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 	public LinkedList<RecipeTransferRect> transferRectsGui = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
 	public LinkedList<Class<? extends GuiContainer>> guiGui = new LinkedList<Class<? extends GuiContainer>>();
-	
+
 	/// SETUP ///
 	public final String display;
 	public final ItemStack[] machine;
@@ -47,7 +47,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 		this.recipes = recipes;
 		this.machineOverrides = null;
 	}
-	
+
 	public NEIUniversalHandler(String display, HashMap recipes, HashMap machines) {
 		this(display, (ItemStack[]) null, recipes);
 		this.machineOverrides = machines;
@@ -58,7 +58,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 	public NEIUniversalHandler(String display, Block machine, HashMap recipes) {		this(display, new ItemStack(machine), recipes); }
 
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
-		
+
 		PositionedStack[] input;
 		PositionedStack[] output;
 		PositionedStack machinePositioned;
@@ -66,36 +66,36 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 
 		public RecipeSet(ItemStack[][] in, ItemStack[][] out, Object originalInputInstance /* for custom machine lookup */) {
 			this.originalInputInstance = originalInputInstance;
-			
+
 			input = new PositionedStack[in.length];
 			int[][] inPos = NEIUniversalHandler.getInputCoords(in.length);
 			for(int i = 0; i < in.length; i++) {
 				ItemStack[] sub = in[i];
-				this.input[i] = new PositionedStack(sub, inPos[i][0], inPos[i][1]);
+				this.input[i] = NEISafe.positionedStack(sub, inPos[i][0], inPos[i][1]);
 			}
 			output = new PositionedStack[out.length];
 			int[][] outPos = NEIUniversalHandler.getOutputCoords(out.length);
 			for(int i = 0; i < out.length; i++) {
 				ItemStack[] sub = out[i];
-				this.output[i] = new PositionedStack(sub, outPos[i][0], outPos[i][1]);
+				this.output[i] = NEISafe.positionedStack(sub, outPos[i][0], outPos[i][1]);
 			}
-			
+
 			ItemStack[] m = machine;
-			
+
 			if(NEIUniversalHandler.this.machineOverrides != null) {
 				Object key = NEIUniversalHandler.this.machineOverrides.get(originalInputInstance);
-				
+
 				if(key != null) {
-					this.machinePositioned = new PositionedStack(key, 75, 31);
+					this.machinePositioned = NEISafe.positionedStack(key, 75, 31);
 				}
 			}
-			
-			if(machinePositioned == null) this.machinePositioned = new PositionedStack(m, 75, 31);
+
+			if(machinePositioned == null) this.machinePositioned = NEISafe.positionedStack(m, 75, 31);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, Arrays.asList(input));
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, Arrays.asList(input));
 		}
 
 		@Override
@@ -110,7 +110,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 				other.add(pos);
 			}
 			other.add(machinePositioned);
-			return getCycledIngredients(cycleticks / 20, other);
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, other);
 		}
 	}
 
@@ -127,7 +127,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 	@Override
 	public void drawBackground(int recipe) {
 		super.drawBackground(recipe);
-		
+
 		RecipeSet rec = (RecipeSet) this.arecipes.get(recipe);
 
 		int[][] inPos = NEIUniversalHandler.getInputCoords(rec.input.length);
@@ -138,12 +138,12 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 		for(int[] pos : outPos) {
 			drawTexturedModalRect(pos[0] - 1, pos[1] - 1, 5, 87, 18, 18);
 		}
-		
+
 		drawTexturedModalRect(74, 14, 59, 87, 18, 36);
 	}
-	
+
 	public static int[][] getInputCoords(int count) {
-		
+
 		switch(count) {
 		case 1: return new int[][] {
 			{48, 24}
@@ -209,12 +209,12 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 			{12, 24 + 18}
 		};
 		}
-		
+
 		return new int[count][2];
 	}
-	
+
 	public static int[][] getOutputCoords(int count) {
-		
+
 		switch(count) {
 		case 1: return new int[][] {
 			{102, 24}
@@ -257,25 +257,26 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 			{138, 24}, {138, 32},
 		};
 		}
-		
+
 		return new int[count][2];
 	}
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals(getKey())) {
-			
+
 			outer: for(Entry<Object, Object> recipe : recipes.entrySet()) {
-				ItemStack[][] ins = InventoryUtil.extractObject(recipe.getKey());
-				ItemStack[][] outs = InventoryUtil.extractObject(recipe.getValue());
-				
-				for(ItemStack[] array : ins) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-				for(ItemStack[] array : outs) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-				
+				ItemStack[][] ins = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getKey()));
+				ItemStack[][] outs = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getValue()));
+				if(ins == null || outs == null) continue;
+
+				for(ItemStack[] array : ins) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+				for(ItemStack[] array : outs) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+
 				this.arecipes.add(new RecipeSet(ins, outs, recipe.getKey()));
 			}
-			
+
 		} else {
 			super.loadCraftingRecipes(outputId, results);
 		}
@@ -283,14 +284,15 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		outer: for(Entry<Object, Object> recipe : recipes.entrySet()) {
-			ItemStack[][] ins = InventoryUtil.extractObject(recipe.getKey());
-			ItemStack[][] outs = InventoryUtil.extractObject(recipe.getValue());
-			
-			for(ItemStack[] array : ins) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-			for(ItemStack[] array : outs) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-			
+			ItemStack[][] ins = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getKey()));
+			ItemStack[][] outs = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getValue()));
+			if(ins == null || outs == null) continue;
+
+			for(ItemStack[] array : ins) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+			for(ItemStack[] array : outs) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+
 			match:
 			for(ItemStack[] array : outs) {
 				for(ItemStack stack : array) {
@@ -314,14 +316,15 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		outer: for(Entry<Object, Object> recipe : recipes.entrySet()) {
-			ItemStack[][] ins = InventoryUtil.extractObject(recipe.getKey());
-			ItemStack[][] outs = InventoryUtil.extractObject(recipe.getValue());
-			
-			for(ItemStack[] array : ins) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-			for(ItemStack[] array : outs) for(ItemStack stack : array) if(stack.getItem() == ModItems.item_secret) continue outer;
-			
+			ItemStack[][] ins = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getKey()));
+			ItemStack[][] outs = NEISafe.copyValid2D(InventoryUtil.extractObject(recipe.getValue()));
+			if(ins == null || outs == null) continue;
+
+			for(ItemStack[] array : ins) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+			for(ItemStack[] array : outs) for(ItemStack stack : array) if(NEISafe.isValid(stack) && stack.getItem() == ModItems.item_secret) continue outer;
+
 			match:
 			for(ItemStack[] array : ins) {
 				for(ItemStack stack : array) {
@@ -333,7 +336,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 			}
 		}
 	}
-	
+
 	@Override
 	public void loadTransferRects() {
 		transferRectsGui = new LinkedList<RecipeTransferRect>();
@@ -341,7 +344,7 @@ public abstract class NEIUniversalHandler extends TemplateRecipeHandler implemen
 		transferRects.add(new RecipeTransferRect(new Rectangle(147, 1, 18, 18), getKey()));
 		RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
 	}
-	
+
 	public abstract String getKey();
 
 	@Override

--- a/src/main/java/com/hbm/handler/nei/PressRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/PressRecipeHandler.java
@@ -27,7 +27,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
 @Untested
-public class PressRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class PressRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -52,14 +52,14 @@ public class PressRecipeHandler extends TemplateRecipeHandler implements ICompat
 
 		public SmeltingSet(Object stamp, AStack input, ItemStack result) {
 			input.stacksize = 1;
-			this.input = new PositionedStack(input.extractForNEI(), 83 - 35, 5 + 36 + 1);
-			this.result = new PositionedStack(result, 83 + 28, 5 + 18 + 1);
-			this.stamp = new PositionedStack(stamp, 83 - 35, 6, false);
+			this.input = NEISafe.positionedStack(input.extractForNEI(), 83 - 35, 5 + 36 + 1);
+			this.result = NEISafe.positionedStack(result, 83 + 28, 5 + 18 + 1);
+			this.stamp = NEISafe.positionedStack(stamp, 83 - 35, 6, false);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(input, stamp));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(input, stamp));
 		}
 
 		@Override
@@ -81,9 +81,9 @@ public class PressRecipeHandler extends TemplateRecipeHandler implements ICompat
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
 		if((outputId.equals("pressing")) && getClass() == PressRecipeHandler.class) {
-			
+
 			HashMap<Pair<AStack, StampType>, ItemStack> recipes = PressRecipes.recipes;
-			
+
 			for(Map.Entry<Pair<AStack, StampType>, ItemStack> recipe : recipes.entrySet()) {
 				this.arecipes.add(new SmeltingSet(ItemStamp.stamps.get(recipe.getKey().getValue()), recipe.getKey().getKey(), recipe.getValue()));
 			}
@@ -94,9 +94,9 @@ public class PressRecipeHandler extends TemplateRecipeHandler implements ICompat
 
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
-		
+
 		HashMap<Pair<AStack, StampType>, ItemStack> recipes = PressRecipes.recipes;
-		
+
 		for(Map.Entry<Pair<AStack, StampType>, ItemStack> recipe : recipes.entrySet()) {
 			if(NEIServerUtils.areStacksSameType(recipe.getValue(), result))
 				this.arecipes.add(new SmeltingSet(ItemStamp.stamps.get(recipe.getKey().getValue()), recipe.getKey().getKey(), recipe.getValue()));
@@ -114,13 +114,13 @@ public class PressRecipeHandler extends TemplateRecipeHandler implements ICompat
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
-		
+
 		HashMap<Pair<AStack, StampType>, ItemStack> recipes = PressRecipes.recipes;
-		
+
 		for(Map.Entry<Pair<AStack, StampType>, ItemStack> recipe : recipes.entrySet()) {
 			AStack in = recipe.getKey().getKey();
 			StampType stamp = recipe.getKey().getValue();
-			
+
 			if(in.matchesRecipe(ingredient, true))
 				this.arecipes.add(new SmeltingSet(ItemStamp.stamps.get(recipe.getKey().getValue()), new ComparableStack(ingredient), recipe.getValue()));
 			else if(ingredient.getItem() instanceof ItemStamp && ((ItemStamp)ingredient.getItem()).getStampType(ingredient.getItem(), ingredient.getItemDamage()) == stamp)

--- a/src/main/java/com/hbm/handler/nei/RadiolysisRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/RadiolysisRecipeHandler.java
@@ -19,7 +19,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class RadiolysisRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class RadiolysisRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -34,34 +34,35 @@ public class RadiolysisRecipeHandler extends TemplateRecipeHandler implements IC
 	public LinkedList<RecipeTransferRect> transferRectsGui = new LinkedList<RecipeTransferRect>();
 	public LinkedList<Class<? extends GuiContainer>> guiRec = new LinkedList<Class<? extends GuiContainer>>();
 	public LinkedList<Class<? extends GuiContainer>> guiGui = new LinkedList<Class<? extends GuiContainer>>();
-		
+
 	public class RecipeSet extends TemplateRecipeHandler.CachedRecipe {
 		PositionedStack input;
 		PositionedStack output1;
 		PositionedStack output2;
-		
+
 		public RecipeSet(ItemStack input, ItemStack output1, ItemStack output2) {
-			input.stackSize = 1;
-			this.input = new PositionedStack(input, 34, 25);
-			this.output1 = new PositionedStack(output1, 118, 16);
-			this.output2 = new PositionedStack(output2, 118, 34);
+			input = NEISafe.copy(input);
+			if(input != null) input.stackSize = 1;
+			this.input = NEISafe.positionedStack(input, 34, 25);
+			this.output1 = NEISafe.positionedStack(output1, 118, 16);
+			this.output2 = NEISafe.positionedStack(output2, 118, 34);
 		}
-		
+
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 20, Arrays.asList(input));
+			return NEISafe.getCycledIngredients(this, cycleticks / 20, Arrays.asList(input));
 		}
-		
+
 		@Override
 		public PositionedStack getResult() {
 			return output1;
 		}
-		
+
 		@Override
 		public List<PositionedStack> getOtherStacks() {
 			List<PositionedStack> stacks = new ArrayList<PositionedStack>();
 			stacks.add(output2);
-			return stacks;
+			return NEISafe.cleanPositionedList(stacks);
 		}
 	}
 
@@ -74,13 +75,13 @@ public class RadiolysisRecipeHandler extends TemplateRecipeHandler implements IC
 	public String getGuiTexture() {
 		return RefStrings.MODID + ":textures/gui/nei/gui_nei_radiolysis.png";
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmRadiolysis")) {
 			HashMap<Object, Object[]> recipes = (HashMap<Object, Object[]>) RadiolysisRecipes.getRecipesForNEI();
-			
+
 			for(Entry<Object, Object[]> recipe : recipes.entrySet()) {
 				this.arecipes.add(new RecipeSet((ItemStack)recipe.getKey(), (ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1]));
 			}
@@ -88,31 +89,31 @@ public class RadiolysisRecipeHandler extends TemplateRecipeHandler implements IC
 			super.loadCraftingRecipes(outputId, results);
 		}
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(ItemStack result) {
 		HashMap<Object, Object[]> recipes = (HashMap<Object, Object[]>) RadiolysisRecipes.getRecipesForNEI();
-		
+
 		for(Entry<Object, Object[]> recipe : recipes.entrySet()) {
 			if(compareFluidStacks((ItemStack)recipe.getValue()[0], result) || compareFluidStacks((ItemStack)recipe.getValue()[1], result))
 				this.arecipes.add(new RecipeSet((ItemStack)recipe.getKey(), (ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1]));
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmRadiolysis")) {
 			loadCraftingRecipes("ntmRadiolysis", new Object[0]);
 		} else {
 			super.loadUsageRecipes(inputId, ingredients);
 		}
 	}
-	
+
 	@Override
 	public void loadUsageRecipes(ItemStack ingredient) {
 		HashMap<Object, Object[]> recipes = (HashMap<Object, Object[]>) RadiolysisRecipes.getRecipesForNEI();
-		
+
 		for(Entry<Object, Object[]> recipe : recipes.entrySet()) {
 			if(compareFluidStacks((ItemStack)recipe.getKey(), ingredient))
 				this.arecipes.add(new RecipeSet((ItemStack)recipe.getKey(), (ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1]));
@@ -120,24 +121,24 @@ public class RadiolysisRecipeHandler extends TemplateRecipeHandler implements IC
 	}
 
 	private boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
-	
+
 	@Override
 	public void drawExtras(int recipe) {
 		drawProgressBar(52, 19, 5, 87, 64, 28, 60, 0);
 	}
-	
+
 	@Override
 	public void loadTransferRects() {
 		transferRectsGui = new LinkedList<RecipeTransferRect>();
 		guiGui = new LinkedList<Class<? extends GuiContainer>>();
-		
+
 		transferRects.add(new RecipeTransferRect(new Rectangle(52, 19, 64, 27), "ntmRadiolysis"));
 		transferRectsGui.add(new RecipeTransferRect(new Rectangle(66, 25, 25, 14), "ntmRadiolysis"));
 		guiGui.add(GUIRadiolysis.class);
 		RecipeTransferRectHandler.registerRectsToGuis(getRecipeTransferRectGuis(), transferRects);
 		RecipeTransferRectHandler.registerRectsToGuis(guiGui, transferRectsGui);
 	}
-	
+
 }

--- a/src/main/java/com/hbm/handler/nei/RefineryRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/RefineryRecipeHandler.java
@@ -18,7 +18,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class RefineryRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -43,18 +43,19 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 		PositionedStack result5;
 
 		public SmeltingSet(ItemStack input, ItemStack result1, ItemStack result2, ItemStack result3, ItemStack result4, ItemStack result5) {
-			input.stackSize = 1;
-			this.input = new PositionedStack(input, 21 + 27, 6 + 18);
-			this.result1 = new PositionedStack(result1, 129 - 18, 6);
-			this.result2 = new PositionedStack(result2, 147 - 18, 6 + 9);
-			this.result3 = new PositionedStack(result3, 129 - 18, 42 - 18);
-			this.result4 = new PositionedStack(result4, 147 - 18, 42 - 9);
-			this.result5 = new PositionedStack(result5, 147 - 36, 42);
+			input = NEISafe.copy(input);
+			if(input != null) input.stackSize = 1;
+			this.input = NEISafe.positionedStack(input, 21 + 27, 6 + 18);
+			this.result1 = NEISafe.positionedStack(result1, 129 - 18, 6);
+			this.result2 = NEISafe.positionedStack(result2, 147 - 18, 6 + 9);
+			this.result3 = NEISafe.positionedStack(result3, 129 - 18, 42 - 18);
+			this.result4 = NEISafe.positionedStack(result4, 147 - 18, 42 - 9);
+			this.result5 = NEISafe.positionedStack(result5, 147 - 36, 42);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
 		}
 
 		@Override
@@ -64,7 +65,7 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 			stacks.add(result3);
 			stacks.add(result4);
 			stacks.add(result5);
-			return stacks;
+			return NEISafe.cleanPositionedList(stacks);
 		}
 
 		@Override
@@ -72,7 +73,7 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 			return result1;
 		}
 	}
-    
+
 	@Override
 	public String getRecipeName() {
 		return "Refinery";
@@ -92,15 +93,15 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 	public TemplateRecipeHandler newInstance() {
 		return super.newInstance();
 	}
-	
+
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
 		if ((outputId.equals("refinery")) && getClass() == RefineryRecipeHandler.class) {
 			Map<Object, Object[]> recipes = RefineryRecipes.getRefineryRecipe();
 			for (Map.Entry<Object, Object[]> recipe : recipes.entrySet()) {
-				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(), 
-						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1], 
-						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3], 
+				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(),
+						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1],
+						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3],
 						(ItemStack)recipe.getValue()[4]));
 			}
 		} else {
@@ -112,14 +113,14 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 	public void loadCraftingRecipes(ItemStack result) {
 		Map<Object, Object[]> recipes = RefineryRecipes.getRefineryRecipe();
 		for (Map.Entry<Object, Object[]> recipe : recipes.entrySet()) {
-			if (compareFluidStacks((ItemStack)recipe.getValue()[0], result) || 
-					compareFluidStacks((ItemStack)recipe.getValue()[1], result) || 
-					compareFluidStacks((ItemStack)recipe.getValue()[2], result) || 
-					compareFluidStacks((ItemStack)recipe.getValue()[3], result) || 
+			if (compareFluidStacks((ItemStack)recipe.getValue()[0], result) ||
+					compareFluidStacks((ItemStack)recipe.getValue()[1], result) ||
+					compareFluidStacks((ItemStack)recipe.getValue()[2], result) ||
+					compareFluidStacks((ItemStack)recipe.getValue()[3], result) ||
 					compareFluidStacks((ItemStack)recipe.getValue()[4], result))
-				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(), 
-						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1], 
-						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3], 
+				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(),
+						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1],
+						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3],
 						(ItemStack)recipe.getValue()[4]));
 		}
 	}
@@ -138,15 +139,15 @@ public class RefineryRecipeHandler extends TemplateRecipeHandler implements ICom
 		Map<Object, Object[]> recipes = RefineryRecipes.getRefineryRecipe();
 		for (Map.Entry<Object, Object[]> recipe : recipes.entrySet()) {
 			if (compareFluidStacks(ingredient, (ItemStack)recipe.getKey()))
-				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(), 
-						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1], 
-						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3], 
-						(ItemStack)recipe.getValue()[4]));				
+				this.arecipes.add(new SmeltingSet((ItemStack)recipe.getKey(),
+						(ItemStack)recipe.getValue()[0], (ItemStack)recipe.getValue()[1],
+						(ItemStack)recipe.getValue()[2], (ItemStack)recipe.getValue()[3],
+						(ItemStack)recipe.getValue()[4]));
 		}
 	}
-	
+
 	private boolean compareFluidStacks(ItemStack sta1, ItemStack sta2) {
-		return sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
+		return NEISafe.isValid(sta1) && NEISafe.isValid(sta2) && sta1.getItem() == sta2.getItem() && sta1.getItemDamage() == sta2.getItemDamage();
 	}
 
 	@Override

--- a/src/main/java/com/hbm/handler/nei/SILEXRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/SILEXRecipeHandler.java
@@ -26,7 +26,7 @@ import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 
-public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class SILEXRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -51,53 +51,53 @@ public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompat
 		EnumWavelengths crystalStrength;
 
 		public RecipeSet(Object input, SILEXRecipe recipe) {
-			
-			this.input = new PositionedStack(input, 12, 24);
+
+			this.input = NEISafe.positionedStack(input, 12, 24);
 			this.outputs = new ArrayList<PositionedStack>();
 			this.chances = new ArrayList<Double>();
 			this.produced = recipe.fluidProduced / recipe.fluidConsumed;
 			this.crystalStrength = recipe.laserStrength;
-			
+
 			double weight = 0;
-			
+
 			for(WeightedRandomObject obj : recipe.outputs) {
 				weight += obj.itemWeight;
 			}
-			
+
 			int sep = recipe.outputs.size() > 4 ? 3 : 2;
-			
+
 			for(int i = 0; i < recipe.outputs.size(); i++) {
-				
+
 				WeightedRandomObject obj = recipe.outputs.get(i);
-				
+
 				if(i < sep) {
-					outputs.add(new PositionedStack(obj.asStack(), 68, 24 + i * 18 - 9 * ((Math.min(recipe.outputs.size(), sep) + 1) / 2)));
+					outputs.add(NEISafe.positionedStack(obj.asStack(), 68, 24 + i * 18 - 9 * ((Math.min(recipe.outputs.size(), sep) + 1) / 2)));
 				} else {
-					outputs.add(new PositionedStack(obj.asStack(), 116, 24 + (i - sep) * 18 - 9 * ((Math.min(recipe.outputs.size() - sep, sep) + 1) / 2)));
+					outputs.add(NEISafe.positionedStack(obj.asStack(), 116, 24 + (i - sep) * 18 - 9 * ((Math.min(recipe.outputs.size() - sep, sep) + 1) / 2)));
 				}
-				
+
 				chances.add(100 * obj.itemWeight / weight);
 			}
-			
+
 			/*for(WeightedRandomObject obj : recipe.outputs) {
-				outputs.add(new PositionedStack(obj.asStack(), 65, 24 + off - 9 * ((recipe.outputs.size()) / 2) + 1));
+				outputs.add(NEISafe.positionedStack(obj.asStack(), 65, 24 + off - 9 * ((recipe.outputs.size()) / 2) + 1));
 				off += 18;
 			}*/
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(input));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(input));
 		}
 
 		@Override
 		public List<PositionedStack> getOtherStacks() {
-			return outputs;
+			return NEISafe.cleanPositionedList(outputs);
 		}
 
 		@Override
 		public PositionedStack getResult() {
-			return outputs.get(0);
+			return NEISafe.firstValid(outputs);
 		}
 	}
 
@@ -112,7 +112,7 @@ public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompat
 		if(outputId.equals("silex") && getClass() == SILEXRecipeHandler.class) {
 
 			Map<Object, SILEXRecipe> recipes = SILEXRecipes.getRecipes();
-			
+
 			for (Map.Entry<Object, SILEXRecipe> recipe : recipes.entrySet()) {
 				this.arecipes.add(new RecipeSet(recipe.getKey(), recipe.getValue()));
 			}
@@ -130,7 +130,7 @@ public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompat
 		for(Map.Entry<Object, SILEXRecipe> recipe : recipes.entrySet()) {
 
 			for(WeightedRandomObject out : recipe.getValue().outputs) {
-				
+
 				if(NEIServerUtils.areStacksSameTypeCrafting(out.asStack(), result)) {
 					this.arecipes.add(new RecipeSet(recipe.getKey(), recipe.getValue()));
 				}
@@ -154,14 +154,14 @@ public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompat
 		Map<Object, SILEXRecipe> recipes = SILEXRecipes.getRecipes();
 
 		for(Map.Entry<Object, SILEXRecipe> recipe : recipes.entrySet()) {
-			
+
 			if(recipe.getKey() instanceof ItemStack) {
 
 				if (NEIServerUtils.areStacksSameTypeCrafting(ingredient, (ItemStack)recipe.getKey()))
 					this.arecipes.add(new RecipeSet(recipe.getKey(), recipe.getValue()));
-				
+
 			} else if (recipe.getKey() instanceof ArrayList) {
-				
+
 				for(Object o : (ArrayList)recipe.getKey()) {
 					ItemStack stack = (ItemStack)o;
 
@@ -196,23 +196,23 @@ public class SILEXRecipeHandler extends TemplateRecipeHandler implements ICompat
 			fontRenderer.drawString(((int)(chance * 10D) / 10D) + "%", 84, 28 + index * 18 - 9 * ((rec.chances.size() + 1) / 2), 0x404040);
 			index++;
 		}*/
-		
+
 		for(int i = 0; i < rec.chances.size(); i++) {
-			
+
 			double chance = rec.chances.get(i);
-			
+
 			PositionedStack sta = rec.outputs.get(i);
-			
+
 			fontRenderer.drawString(((int)(chance * 10D) / 10D) + "%", sta.relx + 18, sta.rely + 4, 0x404040);
 		}
-		
+
 		String am = ((int)(rec.produced * 10D) / 10D) + "x";
 		fontRenderer.drawString(am, 52 - fontRenderer.getStringWidth(am) / 2, 43, 0x404040);
-		
+
 		String wavelength = (rec.crystalStrength == EnumWavelengths.NULL) ? EnumChatFormatting.WHITE + "N/A" : rec.crystalStrength.textColor + I18nUtil.resolveKey(rec.crystalStrength.name);
 		fontRenderer.drawString(wavelength, (33 - fontRenderer.getStringWidth(wavelength) / 2), 8, 0x404040);
-		
-		
+
+
 	}
 
 	@Override

--- a/src/main/java/com/hbm/handler/nei/SafeTemplateRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/SafeTemplateRecipeHandler.java
@@ -1,0 +1,40 @@
+package com.hbm.handler.nei;
+
+import java.util.ArrayList;
+
+import codechicken.nei.recipe.TemplateRecipeHandler;
+
+/**
+ * TemplateRecipeHandler base which rejects malformed cached recipes before GTNH
+ * NEI can build recipe ids/favorites from them.
+ */
+public abstract class SafeTemplateRecipeHandler extends TemplateRecipeHandler {
+
+	public SafeTemplateRecipeHandler() {
+		this.arecipes = new SafeRecipeList(this);
+	}
+
+	private static class SafeRecipeList extends ArrayList<TemplateRecipeHandler.CachedRecipe> {
+		private static final long serialVersionUID = 1L;
+		private final SafeTemplateRecipeHandler handler;
+
+		private SafeRecipeList(SafeTemplateRecipeHandler handler) {
+			this.handler = handler;
+		}
+
+		@Override
+		public boolean add(TemplateRecipeHandler.CachedRecipe recipe) {
+			if(NEISafe.isSafeRecipe(handler, recipe, "add")) {
+				return super.add(recipe);
+			}
+			return false;
+		}
+
+		@Override
+		public void add(int index, TemplateRecipeHandler.CachedRecipe element) {
+			if(NEISafe.isSafeRecipe(handler, element, "indexed add")) {
+				super.add(index, element);
+			}
+		}
+	}
+}

--- a/src/main/java/com/hbm/handler/nei/ShredderRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/ShredderRecipeHandler.java
@@ -21,7 +21,7 @@ import codechicken.nei.recipe.TemplateRecipeHandler;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class ShredderRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class ShredderRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -44,14 +44,15 @@ public class ShredderRecipeHandler extends TemplateRecipeHandler implements ICom
 		PositionedStack result;
 
 		public SmeltingSet(ItemStack input, ItemStack result) {
-			input.stackSize = 1;
-			this.input = new PositionedStack(input, 83 - 27 - 18 + 1, 5 + 18 + 1);
-			this.result = new PositionedStack(result, 83 + 27 + 18 + 1, 5 + 18 + 1);
+			input = NEISafe.copy(input);
+			if(input != null) input.stackSize = 1;
+			this.input = NEISafe.positionedStack(input, 83 - 27 - 18 + 1, 5 + 18 + 1);
+			this.result = NEISafe.positionedStack(result, 83 + 27 + 18 + 1, 5 + 18 + 1);
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(new PositionedStack[] { input }));
 		}
 
 		@Override
@@ -59,7 +60,7 @@ public class ShredderRecipeHandler extends TemplateRecipeHandler implements ICom
 			List<PositionedStack> stacks = new ArrayList<PositionedStack>();
 			stacks.add(fuels.get((cycleticks / 24) % fuels.size()).stack0);
 			stacks.add(fuels.get((cycleticks / 24) % fuels.size()).stack1);
-			return stacks;
+			return NEISafe.cleanPositionedList(stacks);
 		}
 
 		@Override
@@ -71,8 +72,8 @@ public class ShredderRecipeHandler extends TemplateRecipeHandler implements ICom
 	public static class Fuel {
 		public Fuel(ItemStack ingred) {
 
-			this.stack0 = new PositionedStack(ingred, 83 + 1, 5 + 1, false);
-			this.stack1 = new PositionedStack(ingred, 83 + 1, 5 + 36 + 1, false);
+			this.stack0 = NEISafe.positionedStack(ingred, 83 + 1, 5 + 1, false);
+			this.stack1 = NEISafe.positionedStack(ingred, 83 + 1, 5 + 36 + 1, false);
 		}
 
 		public PositionedStack stack0;

--- a/src/main/java/com/hbm/handler/nei/SmithingRecipeHandler.java
+++ b/src/main/java/com/hbm/handler/nei/SmithingRecipeHandler.java
@@ -20,7 +20,7 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.ItemStack;
 
-public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICompatNHNEI {
+public class SmithingRecipeHandler extends SafeTemplateRecipeHandler implements ICompatNHNEI {
 
 	@Override
 	public ItemStack[] getMachinesForRecipe() {
@@ -55,15 +55,15 @@ public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICom
 		int tier;
 
 		public RecipeSet(AnvilSmithingRecipe recipe) {
-			this.input1 = new PositionedStack(recipe.getLeft(), 39, 24);
-			this.input2 = new PositionedStack(recipe.getRight(), 75, 24);
-			this.output = new PositionedStack(recipe.getOutput(input1.item, input2.item), 111, 24);
+			this.input1 = NEISafe.positionedStack(recipe.getLeft(), 39, 24);
+			this.input2 = NEISafe.positionedStack(recipe.getRight(), 75, 24);
+			this.output = NEISafe.positionedStack(recipe.getOutput(NEISafe.firstStack(input1), NEISafe.firstStack(input2)), 111, 24);
 			this.tier = recipe.tier;
 		}
 
 		@Override
 		public List<PositionedStack> getIngredients() {
-			return getCycledIngredients(cycleticks / 48, Arrays.asList(input1, input2));
+			return NEISafe.getCycledIngredients(this, cycleticks / 48, Arrays.asList(input1, input2));
 		}
 
 		@Override
@@ -79,10 +79,10 @@ public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICom
 
 	@Override
 	public void loadCraftingRecipes(String outputId, Object... results) {
-		
+
 		if(outputId.equals("ntmSmithing")) {
 			List<AnvilSmithingRecipe> recipes = AnvilRecipes.getSmithing();
-			
+
 			for(AnvilSmithingRecipe recipe : recipes) {
 				this.arecipes.add(new RecipeSet(recipe));
 			}
@@ -95,7 +95,7 @@ public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICom
 	public void loadCraftingRecipes(ItemStack result) {
 
 		List<AnvilSmithingRecipe> recipes = AnvilRecipes.getSmithing();
-		
+
 		for(AnvilSmithingRecipe recipe : recipes) {
 			if(NEIServerUtils.areStacksSameTypeCrafting(recipe.getSimpleOutput(), result)) {
 				this.arecipes.add(new RecipeSet(recipe));
@@ -105,7 +105,7 @@ public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICom
 
 	@Override
 	public void loadUsageRecipes(String inputId, Object... ingredients) {
-		
+
 		if(inputId.equals("ntmSmithing")) {
 			loadCraftingRecipes("ntmSmithing", new Object[0]);
 		} else {
@@ -117,17 +117,17 @@ public class SmithingRecipeHandler extends TemplateRecipeHandler implements ICom
 	public void loadUsageRecipes(ItemStack ingredient) {
 
 		List<AnvilSmithingRecipe> recipes = AnvilRecipes.getSmithing();
-		
+
 		outer:
 		for(AnvilSmithingRecipe recipe : recipes) {
-			
+
 			for(ItemStack left : recipe.getLeft()) {
 				if(NEIServerUtils.areStacksSameTypeCrafting(left, ingredient)) {
 					this.arecipes.add(new RecipeSet(recipe));
 					continue outer;
 				}
 			}
-			
+
 			for(ItemStack right : recipe.getRight()) {
 				if(NEIServerUtils.areStacksSameTypeCrafting(right, ingredient)) {
 					this.arecipes.add(new RecipeSet(recipe));

--- a/src/main/java/com/hbm/main/NEIConfig.java
+++ b/src/main/java/com/hbm/main/NEIConfig.java
@@ -8,6 +8,7 @@ import com.hbm.blocks.generic.BlockMotherOfAllOres.TileEntityRandomOre;
 import com.hbm.blocks.generic.BlockPlushie.TileEntityPlushie;
 import com.hbm.config.CustomMachineConfigJSON;
 import com.hbm.handler.nei.CustomMachineHandler;
+import com.hbm.handler.nei.NEISafe;
 import com.hbm.items.ModItems;
 import com.hbm.items.machine.ItemBattery;
 import com.hbm.lib.RefStrings;
@@ -132,12 +133,18 @@ public class NEIConfig implements IConfigureNEI {
 	public static void registerHandler(Object o) {
 		API.registerRecipeHandler((ICraftingHandler) o);
 		API.registerUsageHandler((IUsageHandler) o);
+		if(Boolean.getBoolean("hbm.nei.validate") && o instanceof TemplateRecipeHandler) {
+			NEISafe.validateCachedRecipes((TemplateRecipeHandler)o);
+		}
 	}
 
 	/** Bypasses the utterly useless restriction of one registered handler per class */
 	public static void registerHandlerBypass(Object o) {
 		GuiCraftingRecipe.craftinghandlers.add((ICraftingHandler) o);
 		GuiUsageRecipe.usagehandlers.add((IUsageHandler) o);
+		if(Boolean.getBoolean("hbm.nei.validate") && o instanceof TemplateRecipeHandler) {
+			NEISafe.validateCachedRecipes((TemplateRecipeHandler)o);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation
- Prevent NullPointerExceptions in GTNH NEI (favorites / RecipeId extraction / rendering) caused by HBM/RTM recipe handlers exposing null ItemStacks, null PositionedStacks, empty arrays, or malformed recipe objects and apply a global, defensive fix across all HBM NEI handlers.

### Description
- Add a shared safety library `NEISafe` that copies/validates `ItemStack`s, builds safe `PositionedStack`s, filters null/empty arrays/lists, sets permutations safely, and logs skipped malformed recipes once at recipe-cache time, and add `SafeTemplateRecipeHandler` that rejects malformed `CachedRecipe` entries before they are added to `arecipes`.
- Replace direct `new PositionedStack(...)`, raw stack-array passing, and raw `getCycledIngredients` return paths in handlers with `NEISafe.positionedStack(...)`, `NEISafe.copyValid2D(...)`, `NEISafe.getCycledIngredients(...)`, `NEISafe.cleanPositionedList(...)`, `NEISafe.firstValid(...)` and defensive `NEISafe.copy(...)` calls so NEI never sees null/empty displayed entries; handlers skip adding recipes that lack a valid main output or required inputs.
- Handlers updated to use the safe base or helpers include (representative list): universal machine template (`NEIUniversalHandler`) and its subclasses (centrifuge, fluid/fraction/refinery/mixer/cryst./etc.), `AssemblerRecipeHandler`, `AnvilRecipeHandler`/`SmithingRecipeHandler`, `ChemplantRecipeHandler`, `RefineryRecipeHandler`, `CrucibleCastingHandler`/`CrucibleSmeltingHandler`/`CrucibleAlloyingHandler`, `CustomMachineHandler`, `GasCentrifugeRecipeHandler`, `CyclotronRecipeHandler`, `FusionRecipeHandler`, `RadiolysisRecipeHandler`, `ShredderRecipeHandler`, `PressRecipeHandler`, `FluidRecipeHandler`, `SILEXRecipeHandler`, `HadronRecipeHandler`, `AlloyFurnaceRecipeHandler`, `BreederRecipeHandler`, and others under `com.hbm.handler.nei`; optional byproducts are omitted if null while main outputs/required inputs cause the recipe to be skipped and logged.
- Add an opt-in development validator invoked during NEI handler registration when `-Dhbm.nei.validate=true` that iterates cached recipes and reports any invalid/malformed cached entries via `MainRegistry.logger.warn` for developer debugging without changing runtime NEI/CodeChicken/GTNH behavior.

### Testing
- Ran `git diff --check` and fixed whitespace/format issues reported by the check, which completed successfully.
- Attempted `./gradlew compileJava` but compilation could not be executed in this environment because Gradle 4.4.1 fails to determine the system Java version (`25.0.2`), so a full project compile was not completed here.
- Performed repository-wide searches and manual spot checks to confirm handlers now call `NEISafe` helpers (no remaining direct unsafe `new PositionedStack(...)`/raw `getCycledIngredients(...)` return paths in modified handlers) and validated that `arecipes` is backed by the safe list wrapper preventing malformed cached recipes from being added (search/inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d586c67483298eaea3ba60dbae3c)