### PR TITLE
Emit slow carbon monoxide from fuel-burning furnaces and add tooltip

### DIFF
--- a/src/main/java/com/hbm/main/ModEventHandler.java
+++ b/src/main/java/com/hbm/main/ModEventHandler.java
@@ -135,6 +135,8 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatStyle;
@@ -921,6 +923,15 @@ public class ModEventHandler {
 
 
 		if(event.world != null && !event.world.isRemote) {
+
+			if(event.phase == Phase.END && event.world.getTotalWorldTime() % 20 == 0) {
+				for(Object object : event.world.loadedTileEntityList) {
+					if(object instanceof TileEntityFurnace && ((TileEntityFurnace) object).isBurning()) {
+						TileEntity furnace = (TileEntity) object;
+						FurnaceGasEmission.emitCarbonMonoxide(event.world, furnace.xCoord, furnace.yCoord, furnace.zCoord, 30);
+					}
+				}
+			}
 
 			if(reference != null) {
 				for(Object player : event.world.playerEntities) {

--- a/src/main/java/com/hbm/main/ModEventHandlerClient.java
+++ b/src/main/java/com/hbm/main/ModEventHandlerClient.java
@@ -769,6 +769,15 @@ public class ModEventHandlerClient {
 		ItemStack stack = event.itemStack;
 		List<String> list = event.toolTip;
 
+		Item item = stack.getItem();
+		if(item == Item.getItemFromBlock(Blocks.furnace)
+				|| item == Item.getItemFromBlock(ModBlocks.machine_furnace_brick_off)
+				|| item == Item.getItemFromBlock(ModBlocks.furnace_iron)
+				|| item == Item.getItemFromBlock(ModBlocks.machine_difurnace_off)
+				|| item == Item.getItemFromBlock(ModBlocks.machine_rotary_furnace)) {
+			list.add(EnumChatFormatting.DARK_RED + I18nUtil.resolveKey("tooltip.furnace.monoxide"));
+		}
+
 		/// DAMAGE RESISTANCE ///
 		DamageResistanceHandler.addInfo(stack, list);
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnace.java
@@ -13,6 +13,7 @@ import com.hbm.tileentity.IGUIProvider;
 import com.hbm.tileentity.INBTPacketReceiver;
 import com.hbm.tileentity.TileEntityMachinePolluting;
 import com.hbm.util.CompatEnergyControl;
+import com.hbm.util.FurnaceGasEmission;
 
 import api.hbm.fluid.IFluidStandardSender;
 import api.hbm.tile.IInfoProviderEC;
@@ -200,6 +201,7 @@ public class TileEntityDiFurnace extends TileEntityMachinePolluting implements I
 
 			if(canProcess()) {
 
+				FurnaceGasEmission.emitCarbonMonoxide(worldObj, xCoord, yCoord, zCoord, 600);
 				//fuel -= extension ? 2 : 1;
 				fuel -= 1; //switch it up on me, fuel efficiency, on fumes i'm running - running - running - running
 				progress += extension ? 3 : 1;

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityFurnaceBrick.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityFurnaceBrick.java
@@ -10,6 +10,7 @@ import com.hbm.items.ModItems;
 import com.hbm.items.ItemEnums.EnumAshType;
 import com.hbm.tileentity.IGUIProvider;
 import com.hbm.tileentity.TileEntityMachineBase;
+import com.hbm.util.FurnaceGasEmission;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -70,6 +71,7 @@ public class TileEntityFurnaceBrick extends TileEntityMachineBase implements IGU
 			boolean markDirty = false;
 	
 			if(this.burnTime > 0) {
+				FurnaceGasEmission.emitCarbonMonoxide(worldObj, xCoord, yCoord, zCoord, 600);
 				this.burnTime--;
 			}
 	

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityFurnaceIron.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityFurnaceIron.java
@@ -13,6 +13,7 @@ import com.hbm.module.ModuleBurnTime;
 import com.hbm.tileentity.IGUIProvider;
 import com.hbm.tileentity.IUpgradeInfoProvider;
 import com.hbm.tileentity.TileEntityMachineBase;
+import com.hbm.util.FurnaceGasEmission;
 import com.hbm.util.I18nUtil;
 
 import cpw.mods.fml.relauncher.Side;
@@ -89,6 +90,7 @@ public class TileEntityFurnaceIron extends TileEntityMachineBase implements IGUI
 			
 			if(canSmelt() && breatheAir(worldObj.getTotalWorldTime() % 5 == 0 ? 1 : 0)) {
 				wasOn = true;
+				FurnaceGasEmission.emitCarbonMonoxide(worldObj, xCoord, yCoord, zCoord, 600);
 				this.progress++;
 				this.burnTime--;
 				

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineRotaryFurnace.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineRotaryFurnace.java
@@ -23,6 +23,7 @@ import com.hbm.tileentity.IFluidCopiable;
 import com.hbm.tileentity.IGUIProvider;
 import com.hbm.tileentity.TileEntityMachinePolluting;
 import com.hbm.util.CrucibleUtil;
+import com.hbm.util.FurnaceGasEmission;
 import com.hbm.util.fauxpointtwelve.BlockPos;
 import com.hbm.util.fauxpointtwelve.DirPos;
 
@@ -146,6 +147,7 @@ public class TileEntityMachineRotaryFurnace extends TileEntityMachinePolluting i
 
 			this.isVenting = false;
 			if(this.burnTime > 0) {
+				FurnaceGasEmission.emitCarbonMonoxide(worldObj, xCoord, yCoord, zCoord, 600);
 				this.pollute(PollutionType.SOOT, PollutionHandler.SOOT_PER_SECOND / 10F);
 				this.burnTime--;
 			}

--- a/src/main/java/com/hbm/util/FurnaceGasEmission.java
+++ b/src/main/java/com/hbm/util/FurnaceGasEmission.java
@@ -1,0 +1,40 @@
+package com.hbm.util;
+
+import com.hbm.blocks.ModBlocks;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class FurnaceGasEmission {
+
+	private static final ForgeDirection[] OUTPUT_DIRECTIONS = {
+		ForgeDirection.UP,
+		ForgeDirection.NORTH,
+		ForgeDirection.SOUTH,
+		ForgeDirection.WEST,
+		ForgeDirection.EAST
+	};
+
+	private FurnaceGasEmission() { }
+
+	/**
+	 * Attempts to release carbon monoxide into an open block next to a burning furnace.
+	 * Calls are intentionally probabilistic so gas accumulates slowly rather than every tick.
+	 */
+	public static void emitCarbonMonoxide(World world, int x, int y, int z, int chance) {
+		if(world == null || world.isRemote || chance <= 0 || world.rand.nextInt(chance) != 0) return;
+
+		int start = world.rand.nextInt(OUTPUT_DIRECTIONS.length);
+		for(int i = 0; i < OUTPUT_DIRECTIONS.length; i++) {
+			ForgeDirection direction = OUTPUT_DIRECTIONS[(start + i) % OUTPUT_DIRECTIONS.length];
+			int gasX = x + direction.offsetX;
+			int gasY = y + direction.offsetY;
+			int gasZ = z + direction.offsetZ;
+
+			if(world.isAirBlock(gasX, gasY, gasZ)) {
+				world.setBlock(gasX, gasY, gasZ, ModBlocks.gas_monoxide);
+				return;
+			}
+		}
+	}
+}

--- a/src/main/resources/assets/hbm/lang/en_US.lang
+++ b/src/main/resources/assets/hbm/lang/en_US.lang
@@ -5860,6 +5860,7 @@ tile.gas_explosive.name=Explosive Gas
 tile.gas_flammable.name=Flammable Gas
 tile.gas_meltdown.name=Meltdown Gas
 tile.gas_monoxide.name=Carbon Monoxide
+tooltip.furnace.monoxide=Slowly produces carbon monoxide while burning fuel.
 tile.gas_radon.name=Radon Gas
 tile.gas_radon_dense.name=Dense Radon Gas
 tile.gas_radon_tomb.name=Tomb Gas


### PR DESCRIPTION
### Motivation
- Furnaces that burn fuel should slowly produce carbon monoxide (CO) to reflect realistic combustion hazards and encourage use of protection or ventilation.

### Description
- Add a shared helper `FurnaceGasEmission.emitCarbonMonoxide(World,x,y,z,chance)` that probabilistically places `ModBlocks.gas_monoxide` in an adjacent air block so gas accumulates slowly rather than every tick.
- Make vanilla furnaces emit CO via the server world tick handler by checking burning `TileEntityFurnace` instances and calling the emission helper at a low rate (`chance = 30`).
- Make HBM fuel-burning furnaces emit CO while actively consuming fuel by calling the helper from `TileEntityFurnaceBrick`, `TileEntityFurnaceIron`, `TileEntityDiFurnace`, and `TileEntityMachineRotaryFurnace` (uses a higher per-tick chance parameter for similarly slow accumulation).
- Add a client tooltip line by updating `ModEventHandlerClient.drawTooltip` to show `tooltip.furnace.monoxide` for vanilla and HBM furnaces and add the localization text `tooltip.furnace.monoxide=Slowly produces carbon monoxide while burning fuel.` to `en_US.lang`.

### Testing
- Ran repository checks with `git diff --cached --check`, which passed with no whitespace or staging errors.
- Attempted `./gradlew compileJava`, but compilation could not complete because the project’s legacy Gradle (4.4.1) wrapper could not identify the available Java runtime in this environment (Gradle requires Java 8 for this build).
- Attempted to install Java 8 (`mise install java@8`) to run the build, but the installation failed due to network/unavailable download service, so no successful compile-time or runtime tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25e8aa30b0832381b591061eae0c40)