### PR TITLE
Rewrite README and add comprehensive documentation for Ragex's Nuclear Tech Mod (RNTM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,207 +1,232 @@
-# Ragex's Nuclear Tech Mod for Minecraft 1.7.10
+# Ragex's Nuclear Tech Mod
 
-(RTM)
+Ragex's Nuclear Tech Mod (RNTM) is a Minecraft Forge 1.7.10 fork of HBM's Nuclear Tech Mod rebuilt around a more grounded nuclear-technology fantasy. The project goal is not simply to add more late-game content: it removes or de-emphasizes unrealistic/fantasy material from the original project and replaces it with real-world counterparts, plausible industrial processes, or grounded science-fiction systems.
 
-Hi, i am memeing things into existence, dont mind me! im just the bent fork at the end of the table -JamesH_2
+RNTM is intended for players, pack makers, and server operators who want NTM-style scale with a stronger focus on realistic nuclear engineering, chemistry, radiation, ore/oil geology, space environments, and configurable server warfare. Expect more involved processing chains, more reactor and hazard management, and fewer joke/fantasy shortcuts than upstream NTM.
 
-Hello I am RagexPrince683. You may know me from such fantastical tales such as 'the antagonist of NTM' 'ragex broke his pc by sticking his dick in the ram slot' or some other made up nonsense that the absolute super dense black hole that plagues the original HBM's 'nuclear tech' mods 'community' and I put those quotes for good reason. How are you going to label yourself as a nuclear tech mod if there is 0 focus on nuclear tech, and just more ripping from other games? I'm not insulting HBM with this repo, I'm not insulting James with this repo. I like both of their works. However, if you're going to come on this repo and act like a jackass you're not welcome here. I'm not gonna even acknowledge your emotionally charged dick riding for a meme mod that has the capability to simulate legitimate real world technology inside of minecraft. Just because you don't like it doesn't matter. If you're really going to come here and waste your fucking time typing up a wall of shit all day over a mod you didn't make, you deserve to be mad. Infact, how about you get mad at mojang for adding real life animals to the game? or Microsoft for ruining the minecraft scene outside of Java? You come in here and you're mad at me telling me to in essence 'go outside' my friend I am not the one so worked up over a mod you do not own.
+> **Minecraft version:** 1.7.10 only. This project does not target modern Minecraft versions.
 
-I do not care if you don't like realism.
+## Project goals
 
-I don't care if you think my efforts are in vain.
+- **Ground the mod in real or plausible technology.** Fantasy or heavily unrealistic systems from the original project are removed, renamed, reworked, or replaced where practical.
+- **Make nuclear engineering the core identity.** Reactors, radiation, isotopes, fallout, enrichment, treatment, and contamination cleanup are central progression and server systems.
+- **Expand chemistry and industry.** RNTM emphasizes large chemical process chains, periodic-table materials, isotope separation, blast-furnace progression, distillation, and fluid handling.
+- **Make worlds and space feel physical.** Planetary bodies, gas giants, the Sun, orbits, bedrock oil, and bedrock ore deposits are treated as gameplay systems rather than purely decorative dimensions.
+- **Keep dangerous systems configurable.** Server owners can tune or disable nukes, missiles, radiation, worldgen, mobs, dimensions, recipes, and client presentation.
 
-I don't even care how many more commits behind this repo is. I am going to be tweaking things to my liking/for external use.
+## What changed from original HBM's Nuclear Tech Mod
 
-THIS FORK'S DL LINKS: 
+Highlights from the RTM-era direction include:
 
-[RTM MODRINTH](https://modrinth.com/mod/ragexs-nuclear-tech)
+- **Nuclear and radiation overhaul:** reactor systems were reworked, a Molten Salt Reactor was added, WATZ was converted into a Pebble Bed Reactor (PBR), radiation treatment was updated around items such as Prussian Blue IVs, fallout stacking/cleanup became harsher, and more hazard sources were added.
+- **Chemistry expansion:** the fork adds many new chemical processes, expands periodic-table coverage, reworks distillation and isotope separation, improves SILEX enrichment realism, and adds numerous industrial production chains.
+- **World and space rework:** planetary bodies were reworked, gas giant dimensions and Sun travel were added, orbit/time calculations were fixed, and oil/ore deposits were moved toward bedrock-based generation.
+- **Industry and progression rebalance:** steam and fluid systems were rebalanced, blast-furnace usage is emphasized earlier, furnace smelting was adjusted, extra RTG variants were added, the Nuclear Furnace recipe was removed, and research reactors were re-enabled in 528 mode.
+- **Weapons and warfare changes:** CIWS support was re-added/reworked, bombsite support for CSGO Charge was added, and server-side nuclear/missile timing controls exist for admins.
+- **Gameplay and compatibility cleanup:** unrealistic features and recipes such as Power Fist recipes were removed or reduced, while grounded science-fiction content was preserved; Angelica/GTNH NEI compatibility and many rendering/crash fixes were added.
 
-[RTM CF](https://www.curseforge.com/minecraft/mc-mods/ragexs-nuclear-tech)
+See [docs/upstream-changes.md](docs/upstream-changes.md) for a more focused comparison against the original project.
 
-ORIGINAL MOD LINKS:
+## Major feature areas
 
-[NTM Space on Modrinth](https://modrinth.com/mod/ntmspace)
+- **Realism-focused nuclear technology:** MSR, PBR, RBMK/PWR-style systems, research reactors, nuclear fuels, waste handling, meltdowns, fallout, radiation, and nuclear explosions.
+- **Industrial chemistry:** large chemical production chains, isotope work, distillation, SILEX enrichment, acids, fuels, fluids, and periodic-table-driven materials.
+- **Grounded resources:** realistic ore and oil deposit concepts, bedrock extraction, expanded ore processing, metallurgy, and blast-furnace-centered progression.
+- **Power and fluids:** mod-native energy networks, RF-compatible APIs, fluid tanks, fluid traits, gases, fuels, coolants, corrosion, pollution, and radioactive fluid behavior.
+- **Space and celestial bodies:** revised planetary bodies, gas giants, Sun travel, orbital stations, satellites, atmosphere and water-table logic, and station administration commands.
+- **Weapons, hazards, and warfare controls:** guns, explosives, missiles, CIWS, fallout rain, biome damage from detonations, radiation hotspots, scheduled nuke toggles, and server moderation commands.
+- **Configuration and pack tooling:** JSON recipe overrides, custom machines, fluid traits, loot pools, machine-value JSONs, and extensive Forge config categories.
+- **Legacy 1.7.10 compatibility:** NotEnoughItems integration at build/runtime, GTNH NEI fork compatibility notes, OpenComputers API support, Inventory Tweaks compile-time support, Angelica rendering compatibility hooks, and selected legacy-mod compatibility hooks.
 
-[NTM on CurseForge](https://minecraft.curseforge.com/projects/hbms-nuclear-tech-mod?gameCategorySlug=mc-mods&projectID=235439)
+## Download links and resources
 
-[Official NTM Wiki](https://nucleartech.wiki/wiki/Main_Page)
+- **Modrinth:** <https://modrinth.com/mod/ragexs-nuclear-tech>
+- **CurseForge:** <https://www.curseforge.com/minecraft/mc-mods/ragexs-nuclear-tech>
+- **GitHub:** use this repository for source, issues, and development builds.
+- **Original NTM wiki:** <https://nucleartech.wiki/wiki/Main_Page>
+- **Original NTM / related projects:** see [docs/getting-started.md](docs/getting-started.md#related-projects).
 
-**This is for 1.7.10!** For 1.12, check out these projects:
+The original NTM wiki is useful for inherited mechanics, but RNTM intentionally changes progression, names, recipes, radiation behavior, reactors, space, and some item availability. Prefer this repository's docs and generated configs for RNTM-specific behavior.
 
-* NTM Reloaded: https://github.com/TheOriginalGolem/Hbm-s-Nuclear-Tech-GIT/releases
-* NTM Extended Edition (Alcater): https://github.com/Alcatergit/Hbm-s-Nuclear-Tech-GIT/releases
+## Screenshots
 
-For 1.18, try Martin's remake: https://codeberg.org/MartinTheDragon/Nuclear-Tech-Mod-Remake/releases
+Screenshots are not currently stored in this repository. Suggested placeholders for future documentation:
 
-## Downloading pre-compiled versions from GitHub
+| System | Suggested screenshot |
+| --- | --- |
+| Early industry | Starter ore processing and first machines |
+| Nuclear power | Safe reactor layout with control and cooling systems |
+| Space | Orbital station or planetary surface |
+| Hazards | Radiation/fallout or meteor impact example |
 
-Simply navigate to "Releases" on the right side of the page, download links for the compiled JAR as well as the corresponding source code are under the "Assets" category below the changelog. Make sure to review all changelogs when updating!
+## Installation
+
+### Client installation
+
+1. Install **Minecraft 1.7.10**.
+2. Install **Minecraft Forge 1.7.10-10.13.4.1614** or a compatible Forge 1.7.10 build.
+3. Download the RNTM jar from Modrinth, CurseForge, or a GitHub release.
+4. Put the jar in your `.minecraft/mods` folder.
+5. Start the game once so configuration files can generate.
+6. Optional but recommended: install NotEnoughItems for recipe browsing.
+
+### Dedicated server installation
+
+1. Install a Forge 1.7.10 dedicated server.
+2. Put the same RNTM jar in the server `mods` folder.
+3. Start the server once, then stop it after configuration files generate.
+4. Review `config/hbm.cfg`, `config/hbmConfig/*.json`, and `config/hbmRecipes/` templates before opening the world to players.
+5. Restart the server after changing startup-only configuration values.
+
+### Updating an existing world
+
+1. Back up the world, `config/hbm.cfg`, `config/hbmConfig/`, and `config/hbmRecipes/`.
+2. Read the changelog for world generation, dimension, recipe, machine, and registry changes.
+3. Replace the jar.
+4. Start once in a test copy and check the log for missing mappings or config errors.
+5. Only update the production world after the test copy loads correctly.
+
+## Dependencies and compatibility
+
+### Required
+
+- Minecraft **1.7.10**
+- Minecraft Forge **1.7.10-10.13.4.1614** or compatible Forge 1.7.10 runtime
+- Java **8**
+
+### Included or build-time APIs
+
+The source build declares CodeChickenCore, CodeChickenLib, NotEnoughItems, Inventory Tweaks, and OpenComputers API dependencies. Pack authors should test their exact modpack combination because legacy 1.7.10 dependency resolution can vary by launcher and repository availability.
+
+### Client and server requirements
+
+- The mod must be installed on **both client and server** for multiplayer.
+- Clients need the same mod jar as the server unless the server explicitly documents otherwise.
+- Client-only commands and visual configuration are only available on clients.
+- Server-side configuration, world generation, recipes, dimensions, and commands are controlled by the server.
+
+### Known platform warning
+
+The code contains a startup guard for Thermos/fork servers because Thermos tile-entity optimizations can break machine ticking. If you intentionally run Thermos, review the generated `hbm.cfg` Thermos option and the server's `tileentities.yml` before disabling the guard.
+
+## Configuration overview
+
+RNTM generates several configuration locations after first launch:
+
+| Path | Purpose |
+| --- | --- |
+| `config/hbm.cfg` | Main Forge configuration for general toggles, worldgen, nukes, machines, mobs, radiation, dimensions, pollution, and weapons. |
+| `config/hbmConfig/hbmClient.json` | Client display, HUD, tooltip, recoil, render, and debug options. Can be edited in game with `/ntmclient`. |
+| `config/hbmConfig/hbmMachines.json` | Dynamically generated machine values for configurable tile entities. |
+| `config/hbmConfig/hbmCustomMachines.json` | Custom multiblock machine definitions. |
+| `config/hbmConfig/hbmFluidTraits.json` | Fluid behavior traits such as heat, cooling, pollution, radiation, corrosion, and fuel behavior. |
+| `config/hbmConfig/hbmFallout.json` | Fallout block-transformation rules. A `_hbmFallout.json` template is generated until enabled. |
+| `config/hbmConfig/hbmItemPools.json` | Loot/item pool overrides. A `_hbmItemPools.json` template is generated until enabled. |
+| `config/hbmRecipes/` | JSON recipe templates and optional recipe overrides. Remove the leading underscore from a template filename to make it active. |
+
+Important gameplay toggles include:
+
+- `2.0RTM` in `hbm.cfg`: enables or disables nuclear warfare, primarily useful for servers.
+- `enable528Mode`: enables the current 528 progression/balance mode.
+- `enableLessBullshitMode`: easier progression mode; forced off when 528 mode is enabled.
+- `1.42_threadedAtmospheres`: moves atmosphere processing to a separate thread for performance.
+- `6.XX_enableChunkLoading`: allows procedural explosions to keep the central chunk loaded.
+- Dimension IDs and biome IDs in the dimensions/biome categories.
+
+See [docs/configuration.md](docs/configuration.md) for a fuller configuration guide.
+
+## Commands
+
+The server registers these commands:
+
+| Command | Purpose |
+| --- | --- |
+| `/ntmreload` | Reloads serializable recipes and item pools. |
+| `/ntmloadchunk <x> <z>` | Debugs tile entities in an unloaded chunk using block coordinates. |
+| `/ntmsatellites orbit|descend|list` | Manages launched satellites. |
+| `/ntmrad clear` and `/ntmrad set <amount>` | Clears or sets chunk radiation. |
+| `/ntmstations launch|tp|list|fetch` | Manages orbital station drives and station teleportation. |
+| `/ntmenablenukes true|false` | Enables or disables nuclear warfare at runtime. |
+| `/ntmenablenukes schedule true|false yyyy-MM-dd HH:mm` | Schedules a nuke toggle for a local server time. |
+| `/hbmbedrockdrop add|remove|list|clear` | Edits the in-memory bedrock excavator drop list. |
+
+Clients also register:
+
+| Command | Purpose |
+| --- | --- |
+| `/ntmclient help|list|reload|get|set` | Views and edits client JSON variables. |
+| `/dumpthreadsandcrashgame dump|crash` | Logs a thread dump and optionally exits the client. Debug use only. |
+
+See [docs/commands.md](docs/commands.md) for syntax, examples, and cautions.
+
+## Getting started
+
+New players should start with [docs/getting-started.md](docs/getting-started.md). In short:
+
+1. Use JEI/NEI-style recipe lookup where available, because the mod has many machines and intermediate materials.
+2. Explore for ores and early structures, then build a basic ore-processing line.
+3. Learn radiation protection before handling fuels, waste, and reactor components.
+4. Treat nuclear devices, high-radiation materials, and space systems as late-game content.
+5. Server operators should review configs before generating a long-term world.
+
+## Troubleshooting and FAQ
+
+### The game crashes or hangs on first launch.
+
+Confirm you are using Minecraft 1.7.10, Java 8, and a compatible Forge 1.7.10 runtime. If running a legacy server fork such as Thermos, review the Thermos warning above.
+
+### Recipes or loot edits are ignored.
+
+Recipe templates in `config/hbmRecipes/` are written with a leading underscore. Remove the underscore from the filename to enable that file. Item pools and fallout rules also use underscore-prefixed templates until you create the active JSON file.
+
+### Clients cannot join my server.
+
+Make sure all clients and the server use the same RNTM jar and compatible dependencies. Config differences that change registries, dimensions, or recipes can also cause issues.
+
+### How do I disable nukes on a server?
+
+Set `2.0RTM=false` in `config/hbm.cfg` before startup, or use `/ntmenablenukes false` at runtime. Use `/ntmenablenukes schedule false yyyy-MM-dd HH:mm` for a scheduled runtime change.
+
+### Can I remove worldgen after a world already exists?
+
+You can disable future generation, but already-generated chunks keep their blocks and structures. For major worldgen changes, start a new world or pre-generate carefully.
 
 ## Building from source
 
-Tired of waiting until the next version comes out? Here is a tutorial on how to compile the very newest version yourself:
-Please note that these installation instructions are assuming you're running Microsoft Windows operating system. Linux users should know what to do by looking at the same guide.
+Requirements:
 
- 1. Make sure you have JDK8 installed. If not, download it from [adoptium.net](https://adoptium.net/?variant=openjdk8&jvmVariant=hotspot)
- 2. If you don't have git installed, download&install it from [here](https://git-scm.com/downloads).
- 3. Open up "Git Bash":
-    * Press Windows Button, type "Git Bash" and press ENTER
- 4. Enter the directory where you would like the sources to be (advanced users can use any directory)
- ```bash
-     cd $HOME/Downloads
- ```
- 5. Download the source code:
- ```bash
-     git clone https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT.git
- ```
- 4. Enter the source code directory
- ```bash
-     cd Hbm-s-Nuclear-Tech-GIT
- ```
- 5. Build the mod
- ```bash
-     ./gradlew build
- ```
- 6. Locate the mod file.
-    1. Open up your file explorer.
-    2. Navigate to the location where you downloaded the sources.
-       * If you exactly followed step 1, it should be `C:/Users/%USER%/Downloads`.
-    3. Enter the downloaded source tree.
-    4. Navigate to `build/libs`.
-    5. Grab the "HBM-NTM-<version>.jar" one.
-        * This is your mod file. You can install it like any other mod by putting it into your mods directory.
+- Java 8 JDK
+- Git
+- Network access to ForgeGradle and legacy Maven repositories
+
+```bash
+git clone <this-repository-url>
+cd Ragexs-Nuclear-Tech-GIT
+./gradlew build
+```
+
+The built jar is written to `build/libs/` with the `RX-RNTM` archive base name.
+
+For an IDE workspace:
+
+```bash
+./gradlew setupDecompWorkspace
+./gradlew eclipse
+```
+
+## Documentation map
+
+- [Getting Started](docs/getting-started.md)
+- [What Changed from Original NTM](docs/upstream-changes.md)
+- [Configuration Guide](docs/configuration.md)
+- [Command Reference](docs/commands.md)
+- [Server Administration Guide](docs/server-admin.md)
+- [Documentation Audit](docs/documentation-audit.md)
 
 ## Contributing
-If you want to make some changes to the mod, follow this guide:
-1. Follow steps 1-2 from *Building from source* section
-2. Create a directory where the repository will reside, using a name that is not "Hbm-s-Nuclear-Tech-GIT"
-3. Download the forge src from [here](https://files.minecraftforge.net/net/minecraftforge/forge/index_1.7.10.html) and extract it into the directory.
-4. Download the source code:
-  * Using Git Bash, enter wherever your directory is located:
-```bash
-    cd $HOME/Downloads
-```
-   * Download the source code:
-```bash
-    git clone https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT.git
- ```
-   * Move or copy every file within the new folder into your directory, making sure to overwrite any files.
-   * Feel free to delete the remaining folder and rename your directory (such as "Hbm-s-Nuclear-Tech-GIT")
-5. Enter the source directory
-```bash
-    cd Hbm-s-Nuclear-Tech-GIT
-```
-6. Setup forge decompilation workspace
-```bash
-    ./gradlew setupDecompWorkspace
-```
-### Necessary for Eclipse users
-7. Generate eclipse files
-```bash
-    ./gradlew eclipse
-```
-8. Switch to the **eclipse** folder inside your directory as a workspace.
-9. If necessary, make sure that Eclipse is using the JDK8.
-   * On Linux, enter Windows>Preferences>Java>Installed JREs.
-      * Click search to navigate to /usr/lib/jvm and open it. Select the Java 8 JDK (e.g., java-8-openjdk).
-      * Afterwards, enter Execution Environment, select JavaSE-1.8, and select the jre listed as a **[perfect match]**
-   * On Windows, you may need to set your JAVA_HOME.
-      * Search for Environment Variables and click Edit the System Environment Variables.
-      * Click Environment Variables. Click new under System Variables.
-      * Enter **JAVA_HOME** under Variable Name and enter the path to your JDK 8 under Variable Value (e.g., C:\Program-Files\Java\jdk1.8.0_102).
-      * In Eclipse, now enter Windows>Preferences>Java>Installed JREs.
-      * Click **Add Standard VM**; in the JRE home, navigate to the directory where the JDK is installed, then click finish and select it.
-10. Code!
 
-## Compatibility notice
-NTM has certain behaviors intended to fix vanilla code or to increase compatibility in certain cases where it otherwise would not be possible. These behaviors have the potential of not playing well with other mods, and while no such cases are currently known, here's a list of them.
+Contributions should keep documentation aligned with source code. Before documenting a command, config key, or feature, verify it in the current codebase. For code changes, use Java 8-compatible syntax and test with the Gradle build where possible.
 
-### Thermos
-Thermos servers (along with its forks such as Crucible) have a "performance" feature that causes all tile entity ticking to slow down if there's no player present in the same chunk. For obvious reasons, this will heavily impact machines and cause phantom issues that, not having knowledge of this "performance" feature, are near impossible to diagnose. By default, NTM will crash on servers running the Thermos base code and print a lengthy message informing server owners about this "performance" feature as well as how to fix the issues it causes. The error message is printed in plain English on the top of the crash log, failure to read (as well as understand) it will leave the server inoperable.
+## License and credits
 
-### Optifine
-One of the most common "performance" mods on 1.7.10, Optifine, achieves an increase in performance by breaking small things in spots that are usually hard to notice, although this can cause severe issues with NTM. A short list of problems, along with some solutions, follows:
-* Get rid of Optifine and use one of the many [other, less intrusive performance mods](https://gist.github.com/makamys/7cb74cd71d93a4332d2891db2624e17c).
-* Blocks with connected textures may become invisible. This can be fixed by toggling triangulation (I do not know what or where this setting is, I just have been told that it exists and that it can fix the problem) or multicore chunk rendering (same here).
-* Entity "optimization" has a tendency to break chunkloading, this is especially noticeable with missiles which rely heavily on chunkloading to work, causing them to freeze mid-air. It's unclear what setting might fix this, and analysis of Optifine's source code (or rather, lack thereof) has not proven useful either.
-   * This issue will also cause orbital stations to never reach orbit, I can't emphasize enough how much pain and misery this "performance" mod will cause you, use Angelica instead.
-
-### Angelica
-In older versions, Angelica caused issues regarding model rendering, often times making 3D models transparent. Ever since the switch to VBOs, models work fine. Another issue was blocks with connected textures not rendering at all, but this too was fixed, meaning as of time of writing there are no major incompatibilities known with Angelica. However there a few minor issues that persist, but those can be fixed:
-* Often times when making a new world, all items appear as white squares. Somehow, scrolling though the NEI pages fixes this permanently
-* Reeds will render weirdly, this is an incompatibility with the "Compact Vertex Format" feature. Disabling it will make reeds look normal
-
-### Skybox chainloader
-NTM adds a few small things to the skybox using a custom skybox renderer. Minecraft can only have a single skybox renderer loaded, so setting the skybox to the NTM custom one would break compatibility with other mods' skyboxes. To mend this, NTM employs a **chainloader**. This chainloader will detect if a different skybox is loaded, save a reference to that skybox and then use NTM's skybox, which when used will also make sure to run the previous modded skybox renderer. In the event that NTM's skybox were to cause trouble, it can be disabled with the config option `1.31_enableSkyboxes`.
-
-### Custom world provider
-A world provider is a piece of code that minecraft can load to determine certain aspects of how the world should be handled, like light levels, sky color, day/night cycle, etc. In order for the Tom impact effects to work, NTM employs such a world provider, although this is known to cause issues with Hardcore Darkness. The world provider can be disabled with the config option `1.32_enableImpactWorldProvider`.
-
-### Stat re-registering
-An often overlooked aspect of Minecraft is its stats, the game keeps track of how many of an item were crafted, placed, broken, etc. By default, Minecraft can only handle vanilla items, modded items would not show up in the stats window. Forge does little to fix this, and since NTM has to keep track of certain things (such as the use of an acidizer for spawning Mask Man) it will run its own code which re-registers all stats for all modded items. In the event that re-registering causes issues, or another mod already does this better already, this behavior can be disabled with the config option `1.33_enableStatReRegistering`.
-
-### Keybind overlap
-An often annoying aspect of modded Minecraft is its keybinds. Even though multiple binds can be assigned the same key, all but one will show up as "conflicting" and only the non-conflicting one will work. Which one this is is usually arbitrary, and there is no reason to have such limitation. Often times keybinds are only applicable in certain scenarios, and a commonly found degree of overlap is within reason. Therefore, NTM will run its own key handling code which allows conflicting keybinds to work. If there should be any issues with this behavior, it can be disabled with the config option `1.34_enableKeybindOverlap`.
-
-### Render distance capping
-There is a common crash caused by Minecraft's render distance slider going out of bounds, this usually happens when uninstalling a mod that extends the render distance (like Optifine) or when downgrading the Minecraft version (newer versions have higher render distance caps). To prevent crashes, the mod will attempt to decrease the render distance if it's above 16 unless Optifine is installed. If this behavior is not desired (for example, because another mod that allows higher render distance is being used), it can be disabled with the config option `1.25_enableRenderDistCheck`.
-
-### Log spam caused by ComparableStack
-In some modpacks (exact mods needed to replicate this are unknown), it's possible that invalid registered items may cause problems for NEI handlers. To prevent crashes, the ComparableStack class used to represent stacks will default to a safe registered item, and print a log message. In certain situations, this may cause dozens of errors to be printed at once, potentially even lagging the game. If that happens, the log message (but not the error handling) can be disabled with the config option `1.28_enableSilentCompStackErrors`.
-
-### Sound system limit
-By default, the sound system only allows a limited amount of sounds to run at once (28 regular sounds and 4 streaming sounds), this causes issues when there's many machines running at once, since their looped sounds will constantly interrupt each other, causing them to immediately restart, which in some isolated cases has proven to cause massive lagspikes. To prevent this, NTM will increase the sound limit to 1000 regular sounds and 50 streaming sounds, this can be disabled with the config option `1.39_enableSoundExtension`.
-
-# License
-This software is licensed under the GNU Lesser General Public License version 3. In short: This software is free, you may run the software freely, create modified versions, distribute this software and distribute modified versions, as long as the modified software too has a free software license (with an exception for linking to this software, as stated by the "Lesser" part of the LGPL, where this may not be required). You win this round, Stallman. The full license can be found in the `LICENSE` and `LICENSE.LESSER` files.
-
-
-
-
-Glad it looks solid — definitely better than "Bob's instinctual detonation™" 😆
-
-Here's what I based the scaling on:
-Core principle:
-
-Blast radius ≈ cube root of yield, because explosive energy expands spherically in 3D space.
-
-🔧 Specifically, I used:
-Tsar Bomba = 50 Mt → scaled to your 500 block radius
-
-Everything else scaled using the cube root law:
-
-radius𝑋=500×(yield𝑋/50 Mt)^1/3
- 
-Then rounded to clean numbers for game use.
-
-📏 What kind of “radius”?
-It's loosely modeled on blast/fireball radius in meters, but abstracted for gameplay, so:
-
-Not exact fireball size (which is smaller than blast damage radius).
-
-Closer to severe blast damage range — where buildings are destroyed and death is near-certain.
-
-Example real-world:
-
-Little Boy (15 kt) had:
-
-~250 m fireball
-
-~1.5 km severe blast radius
-
-In-game, we picked ~40–45 blocks to feel meaningful but not insane.
-
-Why not use real meter-to-block conversion?
-Because Minecraft terrain and scale are abstract:
-
-1 block = 1 meter technically, but terrain is dense, and players move fast.
-
-A literal 2 km radius explosion in MC (2000 blocks) would be unplayable and dumb.
-
-So we strike a balance between:
-
-Realistic relative scaling (cube root of yields)
-
-Playable scale (500 max radius)
-
-Let me know if you want fallout area, airburst vs groundburst effects, or pressure estimates for lore.
+See [LICENSE](LICENSE), [LICENSE.LESSER](LICENSE.LESSER), Forge license files, and [gradle.properties](gradle.properties) credits for licensing and contributor information.

--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+## Documentation
+* Refocused the README and docs on Ragex's Nuclear Tech's purpose as a realism-oriented fork of original NTM.
+* Added a dedicated upstream comparison guide covering removed/reworked fantasy elements, nuclear/radiation changes, chemistry expansion, space/world changes, progression rebalances, warfare controls, and compatibility cleanup.
+
+## Documentation
+* Rewrote the README with a clearer project overview, installation instructions, dependency and compatibility notes, configuration overview, command summary, troubleshooting, and resource links.
+* Added documentation under `docs/` for getting started, configuration, commands, server administration, and documentation audit findings.
+* Documented discovered commands, config files, JSON template behavior, server safety notes, and remaining documentation gaps.
+
 ## Added
 * Mun cows! These rare cows are found on the Mun, they moonwalk and drop cheese. Directly inspired by the 2023 April Fools update
 * Basic atmospheric chemistry

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,229 @@
+# Command Reference
+
+This reference was verified against `src/main/java/com/hbm/commands` and the server command registration in `MainRegistry`.
+
+## Server commands
+
+These commands are registered during server startup.
+
+### `/ntmreload`
+
+Reloads serializable JSON recipes and item pools.
+
+**Usage**
+
+```text
+/ntmreload
+```
+
+**Use when**
+
+- You edited active files in `config/hbmRecipes/`.
+- You edited `config/hbmConfig/hbmItemPools.json`.
+
+**Caution**
+
+This command catches load errors, prints a short error to chat, and rethrows the exception. Test recipe JSON on a staging server before using it on production.
+
+### `/ntmloadchunk <x> <z>`
+
+Debug command that inspects tile entities in an unloaded chunk using block coordinates.
+
+**Usage**
+
+```text
+/ntmloadchunk <x> <z>
+```
+
+**Example**
+
+```text
+/ntmloadchunk 1024 -320
+```
+
+The command converts block coordinates to chunk coordinates internally. It reports tile-entity IDs and positions, highlighting invalid positions.
+
+### `/ntmsatellites orbit|descend|list`
+
+Manages active satellites. Must be run by a player.
+
+**Usage**
+
+```text
+/ntmsatellites orbit
+/ntmsatellites descend <frequency>
+/ntmsatellites list
+```
+
+**Examples**
+
+```text
+/ntmsatellites orbit
+/ntmsatellites list
+/ntmsatellites descend 12345
+```
+
+Notes:
+
+- `orbit` launches the satellite chip held by the player and consumes one item if valid.
+- `descend` removes an active satellite by frequency.
+- `list` prints active satellite frequencies and implementation class names.
+
+### `/ntmrad clear|set`
+
+Edits chunk radiation at the sender's location or clears the radiation data system.
+
+**Usage**
+
+```text
+/ntmrad clear
+/ntmrad set <amount>
+```
+
+**Examples**
+
+```text
+/ntmrad clear
+/ntmrad set 25
+```
+
+`set` accepts values from `0` to `100000`.
+
+### `/ntmstations launch|tp|list|fetch`
+
+Manages orbital stations and station drives. Must be run by a player.
+
+**Usage**
+
+```text
+/ntmstations launch
+/ntmstations tp
+/ntmstations list
+/ntmstations fetch <id|name>
+```
+
+**Examples**
+
+```text
+/ntmstations launch
+/ntmstations tp
+/ntmstations list
+/ntmstations fetch 0xA1B2C3D4
+/ntmstations fetch My Station Name
+```
+
+Notes:
+
+- `launch` creates a station for the held orbit destination drive.
+- `tp` teleports the player to the station represented by the held orbit drive and spawns the station structure if needed.
+- `list` prints station IDs and station names.
+- `fetch` gives the player a programmed drive for a matching station ID or name.
+
+### `/ntmenablenukes true|false`
+
+Enables or disables the runtime nuclear warfare toggle.
+
+**Usage**
+
+```text
+/ntmenablenukes true
+/ntmenablenukes false
+```
+
+**Examples**
+
+```text
+/ntmenablenukes false
+/ntmenablenukes true
+```
+
+This changes the in-memory value of `GeneralConfig.enableNuking`; it is useful for event windows or emergency lockdowns.
+
+### `/ntmenablenukes schedule true|false yyyy-MM-dd HH:mm`
+
+Schedules a runtime nuclear warfare toggle.
+
+**Usage**
+
+```text
+/ntmenablenukes schedule <true|false> <yyyy-MM-dd> <HH:mm>
+```
+
+**Example**
+
+```text
+/ntmenablenukes schedule false 2026-06-09 22:00
+```
+
+The date parser uses the server JVM's local time zone and the format `yyyy-MM-dd HH:mm`.
+
+### `/hbmbedrockdrop add|remove|list|clear`
+
+Edits the in-memory excavator bedrock drop list. Requires permission level 4.
+
+**Usage**
+
+```text
+/hbmbedrockdrop list
+/hbmbedrockdrop clear
+/hbmbedrockdrop remove <index>
+/hbmbedrockdrop add <registry> <meta> <min> <max>
+```
+
+**Examples**
+
+```text
+/hbmbedrockdrop list
+/hbmbedrockdrop add minecraft:diamond 0 1 2
+/hbmbedrockdrop remove 3
+/hbmbedrockdrop clear
+```
+
+The entry format is `modid:item_or_block meta min max`.
+
+## Client commands
+
+These commands are registered only on clients.
+
+### `/ntmclient help|list|reload|get|set`
+
+Views and edits client JSON variables in `config/hbmConfig/hbmClient.json`.
+
+**Usage**
+
+```text
+/ntmclient help
+/ntmclient help <command>
+/ntmclient list
+/ntmclient reload
+/ntmclient get <name>
+/ntmclient set <name> <value>
+```
+
+**Examples**
+
+```text
+/ntmclient list
+/ntmclient get GUN_VISUAL_RECOIL
+/ntmclient set GUN_VISUAL_RECOIL false
+/ntmclient reload
+```
+
+Available keys are listed by `/ntmclient list`. Values are parsed according to the default value type.
+
+### `/dumpthreadsandcrashgame dump|crash`
+
+Debug-only command that writes a thread dump to the log and optionally exits Java.
+
+**Usage**
+
+```text
+/dumpthreadsandcrashgame dump
+/dumpthreadsandcrashgame crash
+```
+
+Only use this command when debugging hangs or crashes. `crash` intentionally exits the client.
+
+## Permissions notes
+
+Most server command classes do not override Forge's default permission behavior. `/hbmbedrockdrop` explicitly requires permission level 4. Server owners should additionally restrict command access with their server management tooling, especially for radiation, stations, satellites, recipe reloads, chunk diagnostics, and nuclear toggles.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,161 @@
+# Configuration Guide
+
+RNTM has three main configuration styles:
+
+1. Forge configuration values in `config/hbm.cfg`.
+2. JSON configuration files in `config/hbmConfig/`.
+3. JSON recipe templates and overrides in `config/hbmRecipes/`.
+
+Always stop the server before editing startup configuration unless a command explicitly supports runtime reloads.
+
+## Main Forge config: `config/hbm.cfg`
+
+The main config is generated from these source categories:
+
+| Category | Typical contents |
+| --- | --- |
+| `01_general` | Debug mode, guide book, MOTD, sound extension, atmosphere threading, nuclear warfare toggle, compatibility toggles, visual/server safety options. |
+| `02_ores` | Overworld, nether, end, bedrock, cluster, oil, gas, and random ore generation rates. |
+| `03_nukes` | Blast radii for nuclear devices and related explosive devices. |
+| `04_dungeons` | Structure spawn frequencies for radio stations, antennas, power plants, factories, capsules, vaults, pyramids, and other generated structures. |
+| `05_meteors` | Meteor strike, shower, tail, special-meteor, chance, and duration settings. |
+| `06_explosions` | Procedural explosion speed, lifespan, fallout range/delay/rain values, and explosion chunk loading. |
+| `07_missile_machines` | Missile machine behavior where applicable. |
+| `08_potion_effects` | Potion IDs and potion-related settings. |
+| `09_machines` | Machine balance and behavior settings. |
+| `10_dangerous_drops` | Dangerous drop behavior where applicable. |
+| `11_tools` | Tool balance and tool behavior settings. |
+| `12_mobs` | Raid, elemental, duck, mob gear, glyphid hive, infestation, and swarm settings. |
+| `13_radiation` | Radiation system tuning. |
+| `14_hazard` | Hazard behavior where applicable. |
+| `15_structures` | Structure toggles/flags. |
+| `16_biomes` | Crater biome IDs and crater radiation values. |
+| `17_dims` | Dimension IDs, celestial body enable flags, and space-related generation values. |
+| `18_pollution` | Pollution behavior where applicable. |
+| `19_weapons` | Weapon balance and behavior settings. |
+| `528` | 528-mode progression/balance controls. |
+| `LESS BULLSHIT MODE` | Easier progression recipe and safety controls; forced off while 528 mode is enabled. |
+
+### High-impact keys
+
+| Key | Default | Meaning |
+| --- | ---: | --- |
+| `2.0RTM` | `true` | Enables nuclear warfare, primarily for server moderation. |
+| `enable528Mode` | `true` | Enables 528 mode. |
+| `enableLessBullshitMode` | `false` | Enables easier progression mode when 528 mode is off. |
+| `1.42_threadedAtmospheres` | `true` | Runs atmosphere blobbing on a separate thread for performance. |
+| `1.43_serverSafety` | `false` | Enables automated entity culling behavior described by the config comment. |
+| `1.99_enableExpensiveMode` | `false` | Enables expensive-mode balance. |
+| `6.XX_enableChunkLoading` | `true` | Allows procedural explosions to keep the central chunk loaded. |
+
+### World generation caution
+
+Ore, structure, meteor, biome, and dimension settings affect world generation and world identity. Changing these on an existing save only affects newly generated content unless the setting controls runtime behavior. Dimension ID changes can strand players or break portals/travel if done after a world has been used.
+
+## Client JSON: `config/hbmConfig/hbmClient.json`
+
+This file stores client-only visual and UI preferences. The file is generated and rewritten by the mod. It can also be edited in game with `/ntmclient`.
+
+Known keys include:
+
+| Key | Default | Purpose |
+| --- | ---: | --- |
+| `GEIGER_OFFSET_HORIZONTAL` | `0` | Horizontal offset for Geiger HUD. |
+| `GEIGER_OFFSET_VERTICAL` | `0` | Vertical offset for Geiger HUD. |
+| `INFO_OFFSET_HORIZONTAL` | `0` | Horizontal offset for info HUD. |
+| `INFO_OFFSET_VERTICAL` | `0` | Vertical offset for info HUD. |
+| `INFO_POSITION` | `0` | Info HUD position mode. |
+| `GUN_ANIMS_LEGACY` | `false` | Legacy gun animation toggle. |
+| `GUN_MODEL_FOV` | `false` | Gun model FOV behavior. |
+| `GUN_VISUAL_RECOIL` | `true` | Visual recoil toggle. |
+| `ITEM_TOOLTIP_SHOW_OREDICT` | `true` | Ore dictionary tooltip display. |
+| `ITEM_TOOLTIP_SHOW_CUSTOM_NUKE` | `true` | Custom nuke tooltip display. |
+| `MAIN_MENU_WACKY_SPLASHES` | `true` | Main menu splash behavior. |
+| `DODD_RBMK_DIAGNOSTIC` | `true` | RBMK diagnostic display behavior. |
+| `RENDER_CABLE_HANG` | `true` | Cable hanging render behavior. |
+| `NUKE_HUD_FLASH` | `true` | Nuke HUD flash effect. |
+| `NUKE_HUD_SHAKE` | `true` | Nuke HUD shake effect. |
+| `RENDER_REEDS` | depends on mod compatibility | Reeds render behavior. |
+| `DEBUG_RENDER_GL_ERRORS` | `false` | OpenGL render error debugging. |
+
+> Note: the current source maps `ITEM_TOOLTIP_SHOW_CUSTOM_NUKE` to the `ITEM_TOOLTIP_SHOW_OREDICT` key during default registration. Treat custom-nuke tooltip editing as a documentation gap until this is clarified or fixed in code.
+
+## Dynamic machine JSON: `config/hbmConfig/hbmMachines.json`
+
+This file is generated from tile entities that implement the configurable-machine interface. Unlike recipe templates, it is the active file: edit the values directly, then restart.
+
+Behavior:
+
+- Missing machine values are restored with defaults on startup.
+- Unknown custom fields may be deleted when the file is rewritten.
+- If an update adds a new machine option, it should be added automatically with its default.
+
+## Custom machines: `config/hbmConfig/hbmCustomMachines.json`
+
+Defines custom multiblock machines. If the file does not exist, the mod writes a default example and reads it.
+
+Because custom machine definitions include blocks, ports, recipe shapes, components, capacities, power, heat, pollution, and IO counts, test all custom definitions in a creative world before deploying to a public server.
+
+## Fluid traits: `config/hbmConfig/hbmFluidTraits.json`
+
+Fluid traits define special fluid behavior. The code supports trait concepts such as:
+
+- combustible or flammable behavior,
+- rocket fuel behavior,
+- heatable/coolable behavior,
+- gaseous behavior,
+- corrosive behavior,
+- poisonous/toxic behavior,
+- PWR moderator behavior,
+- radiation venting behavior,
+- pollution behavior.
+
+The mod writes `_hbmFluidTraits.json` as a template when an active file is not present. Copy or rename the template to `hbmFluidTraits.json` to make custom trait edits active.
+
+## Fallout JSON: `config/hbmConfig/hbmFallout.json`
+
+Defines block transformations caused by fallout. If no active file exists, `_hbmFallout.json` is generated as a template.
+
+Use this for pack-level tuning of how fallout damages or transforms terrain. Test with backups: fallout rules can permanently alter world blocks.
+
+## Item pools: `config/hbmConfig/hbmItemPools.json`
+
+Defines weighted item pools used by loot systems. If no active file exists, `_hbmItemPools.json` is generated as a template.
+
+Entry format is documented inside the generated template. In short, entries combine an item stack definition, minimum amount, maximum amount, and weight.
+
+## Recipe JSON: `config/hbmRecipes/`
+
+Serializable recipes are generated in `config/hbmRecipes/`.
+
+Important behavior:
+
+- If an active recipe file is missing, defaults are registered and a template named `_<filename>` is written.
+- To override recipes, remove the leading underscore from a template file and edit the active file.
+- `/ntmreload` reloads serializable recipes and item pools without a full restart, but test carefully.
+
+## Bedrock excavator drops
+
+`MiningConfig` defines the default in-memory bedrock excavator drop list. Operators can edit this list during runtime with `/hbmbedrockdrop`, using entries in this format:
+
+```text
+modid:item_or_block meta min max
+```
+
+Example:
+
+```text
+minecraft:diamond 0 1 2
+```
+
+The command edits the runtime list; persistence depends on implementation details not fully documented in the current code.
+
+## Recommended server workflow
+
+1. Start a new server once to generate all configs.
+2. Stop the server.
+3. Configure `hbm.cfg` worldgen, dimension IDs, 528/LBS mode, nukes, radiation, and mob systems.
+4. Start a temporary world to generate JSON templates.
+5. Edit recipes, fluid traits, fallout, item pools, and custom machines as needed.
+6. Test with representative players and machines.
+7. Back up the final config set before opening the long-term world.

--- a/docs/documentation-audit.md
+++ b/docs/documentation-audit.md
@@ -1,0 +1,58 @@
+# Documentation Audit
+
+This file records what was discovered during the documentation pass and what remains uncertain.
+
+## Source areas inspected
+
+- `README.md`
+- `build.gradle`
+- `gradle.properties`
+- `src/main/resources/mcmod.info`
+- `src/main/java/com/hbm/main/MainRegistry.java`
+- `src/main/java/com/hbm/commands/*.java`
+- `src/main/java/com/hbm/config/*.java`
+- `src/main/java/com/hbm/inventory/recipes/loader/SerializableRecipe.java`
+- `src/main/java/com/hbm/inventory/fluid/Fluids.java`
+- User-provided RTM update summary for fork-specific design goals and major changes
+
+## Features, commands, configs, or systems documented in this pass
+
+- Runtime nuke enable/disable command and scheduled nuke toggle.
+- Client-side `/ntmclient` command and `hbmClient.json` keys.
+- Debug-only `/dumpthreadsandcrashgame` client command.
+- Station and satellite management commands.
+- Bedrock excavator drop editing command and default entry format.
+- Recipe template activation behavior in `config/hbmRecipes/`.
+- Dynamic machine config behavior in `hbmMachines.json`.
+- Custom machine config file generation.
+- Fallout, item pool, and fluid trait template behavior.
+- Major main-config categories and high-impact toggles such as 528 mode, LBS mode, threaded atmospheres, explosion chunk loading, and nuclear warfare.
+- Thermos/fork server startup warning.
+- RNTM design goals and major upstream differences: realism focus, nuclear/radiation overhaul, chemistry expansion, world/space rework, industry/progression rebalance, warfare controls, compatibility cleanup, and removed/reworked fantasy features.
+
+## Documentation gaps and uncertainties
+
+These items could not be fully documented without deeper gameplay testing, comments, screenshots, or implementation-specific knowledge:
+
+1. **Exact release-by-release upstream delta.** The RTM direction is documented, but a complete inherited/removed/reworked item-by-item comparison against every original NTM release would require generated registries and in-game validation.
+2. **Full progression walkthrough.** The codebase contains many machines and recipes; a complete step-by-step progression guide would require in-game validation.
+3. **Exact dependency packaging.** Build-time dependencies are declared, but runtime packaging expectations can vary in legacy 1.7.10 launcher setups.
+4. **Complete machine-value reference.** `hbmMachines.json` is generated dynamically from registered tile entities, so exact contents depend on runtime registration and should be documented from a generated file.
+5. **Complete recipe reference.** Recipes are numerous and generated as JSON templates; recipe browsing is better handled in-game or from generated files.
+6. **Custom machine schema details.** The default file demonstrates fields, but user-facing documentation would benefit from a schema and tested examples.
+7. **Fluid trait schema details.** Trait classes exist, but a complete validated schema and examples were not produced in this pass.
+8. **Bedrock excavator drop persistence.** `/hbmbedrockdrop` edits `MiningConfig.excavatorBedrockDrops` in memory; persistence was not evident from the inspected command code.
+9. **Permissions.** Most commands do not implement explicit permission overrides, so effective access depends on Forge/vanilla defaults and server tooling.
+10. **Screenshots.** No current screenshots were present in the repository, so the README includes placeholders rather than images.
+11. **External community links.** Modrinth and CurseForge links were available in the old README. No Discord or dedicated RNTM wiki link was verified in the repository.
+12. **Client config key collision.** `ClientConfig` maps `ITEM_TOOLTIP_SHOW_CUSTOM_NUKE` through the `ITEM_TOOLTIP_SHOW_OREDICT` key during default registration, so the intended editable key needs code clarification.
+
+## Recommended next documentation work
+
+- Generate `hbm.cfg`, `hbmConfig/`, and `hbmRecipes/` from a clean runtime and add examples based on those generated files.
+- Add screenshots for early industry, reactor setup, radiation UI, and space stations.
+- Write a validated early-to-mid-game progression guide from actual gameplay.
+- Generate a release-by-release upstream comparison table from registries, recipe outputs, and language files.
+- Add a custom machine schema with one working example.
+- Add a fluid traits schema with one safe example and one hazardous example.
+- Clarify command permissions and persistence behavior in code or server docs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,82 @@
+# Getting Started with Ragex's Nuclear Tech Mod
+
+This guide is for players joining a world or modpack that includes Ragex's Nuclear Tech Mod (RNTM). It avoids hidden implementation details and focuses on practical survival play.
+
+## Before you start
+
+RNTM is a large 1.7.10 technology mod, but it should not be approached as a drop-in copy of original HBM's Nuclear Tech Mod. Progression, recipes, names, reactors, radiation, space, and removed fantasy features can differ because this fork is built around more realistic or plausible counterparts. It expects you to use recipe lookup and to learn systems gradually. The mod includes dangerous blocks, items, fluids, machines, radiation, explosions, and space content; do not treat every item as safe to hold or place.
+
+Recommended setup:
+
+- Minecraft 1.7.10 with Forge.
+- RNTM installed on both client and server.
+- NotEnoughItems or the recipe viewer bundled in your pack, if available.
+- Backups before testing explosives, reactors, or config changes.
+
+## Early-game priorities
+
+1. **Find ores and surface resources.** RNTM adds many ore types and generated resources. Mine broadly and keep unfamiliar ores instead of discarding them.
+2. **Build basic processing.** Prioritize machines that multiply ore output, make plates/circuits, and unlock chemical or metallurgical steps.
+3. **Organize intermediates.** The mod uses many dusts, ingots, plates, fluids, fuel products, and machine components. Dedicated storage prevents progression stalls.
+4. **Read tooltips.** Many items expose hazard, radiation, recipe, or machine information through tooltips.
+5. **Avoid late-game hazards early.** Do not handle radioactive waste, reactor fuel, high explosives, or nuclear devices without understanding consequences.
+
+## Mid-game progression themes
+
+RNTM progression is less about a single linear quest and more about connected real-industry systems:
+
+- **Ore processing and bedrock resources** feed metallurgy and machine crafting.
+- **Blast furnace work** matters earlier than many original-NTM players may expect.
+- **Chemistry and refining** unlock fuels, acids, plastics, isotope work, and advanced materials.
+- **Power generation** scales from basic generators toward reworked nuclear options such as MSR, PBR, RBMK/PWR-style systems, and research reactors.
+- **Radiation protection and treatment** become mandatory around fuels, waste, fallout, and reactor incidents.
+- **Space infrastructure** requires specialized items, destinations, atmosphere awareness, and station/satellite systems.
+
+Use recipe lookup to work backward from a target machine or item. When a material is unfamiliar, search for both its item form and its ore/fluid equivalents.
+
+## Radiation basics
+
+Radiation is a persistent environmental and item hazard. Practical rules:
+
+- Keep radioactive materials contained and away from living areas.
+- Use protective equipment before working with fuel, waste, fallout, or contaminated zones.
+- Do not store radioactive materials in common player inventory unless you know the shielding behavior.
+- Server administrators can clear or set chunk radiation with `/ntmrad`, but players should assume radiation is persistent unless cleaned up.
+
+## Nuclear safety basics
+
+Nuclear systems are powerful but punishing:
+
+- Test reactor designs in a creative copy before using them on a server.
+- Keep backups before first startup of a new reactor design.
+- Monitor heat, coolant, fuel, waste, and output products.
+- Put reactors away from bases and spawn until the design is proven.
+- Treat meltdown, blast, fallout, and biome damage as real world-changing risks.
+
+## Space basics
+
+The mod includes celestial bodies, orbit logic, satellites, and orbital stations. Practical advice:
+
+- Confirm the server's configured dimension IDs before adding other dimension mods.
+- Use station/satellite commands only if you are an operator or the server rules allow it.
+- Keep backup travel items or admin support available when testing station teleportation.
+- Remember that atmosphere and water-table behavior can differ by body.
+
+## Multiplayer etiquette
+
+Because RNTM can damage worlds, ask before:
+
+- Detonating explosives or nukes.
+- Starting an untested reactor.
+- Launching missiles.
+- Creating large pollution/radiation sources.
+- Editing recipes, item pools, machine configs, or dimension IDs.
+
+## Related projects
+
+For other Minecraft versions, use separate projects rather than this repository:
+
+- NTM Reloaded for 1.12: <https://github.com/TheOriginalGolem/Hbm-s-Nuclear-Tech-GIT/releases>
+- NTM Extended Edition for 1.12: <https://github.com/Alcatergit/Hbm-s-Nuclear-Tech-GIT/releases>
+- Nuclear Tech Mod Remake for 1.18: <https://codeberg.org/MartinTheDragon/Nuclear-Tech-Mod-Remake/releases>
+

--- a/docs/server-admin.md
+++ b/docs/server-admin.md
@@ -1,0 +1,124 @@
+# Server Administration Guide
+
+This guide focuses on operating RNTM in multiplayer.
+
+## Pre-launch checklist
+
+Before opening a world to players:
+
+- Confirm all players can run Minecraft 1.7.10, Java 8, Forge, and the same RNTM jar.
+- Generate configs on a test server.
+- Decide whether nuclear warfare is allowed (`2.0RTM` in `hbm.cfg`).
+- Decide whether to use 528 mode or Less Bullshit Mode.
+- Review ore, structure, meteor, mob, radiation, biome, and dimension settings before the first permanent world generation.
+- Reserve dimension IDs if the pack has other dimension mods.
+- Test the exact modpack on a copy before public launch.
+
+## Suggested server rules
+
+Because the mod can permanently damage terrain and player bases, publish rules for:
+
+- Nuclear device use.
+- Missile and explosive testing areas.
+- Reactor construction near claims/spawn.
+- Radioactive waste disposal.
+- Pollution-heavy industry.
+- Space station naming and ownership.
+- Use of admin commands.
+
+## Nuclear warfare controls
+
+Startup/default control:
+
+```text
+config/hbm.cfg -> 01_general -> 2.0RTM
+```
+
+Runtime controls:
+
+```text
+/ntmenablenukes false
+/ntmenablenukes true
+/ntmenablenukes schedule false 2026-06-09 22:00
+```
+
+Use runtime toggles for events or emergencies, but keep the config aligned with your intended default after restart.
+
+## Radiation cleanup and incidents
+
+Useful command:
+
+```text
+/ntmrad clear
+/ntmrad set <amount>
+```
+
+Recommended incident workflow:
+
+1. Stop players entering the area.
+2. Make a backup if the world is still stable.
+3. Inspect the area in creative/admin mode.
+4. Decide whether to clean, rollback, or quarantine.
+5. Use `/ntmrad clear` only when you intend to clear radiation data broadly for the current world context.
+
+## Recipe and loot changes
+
+- Use `config/hbmRecipes/` for serializable recipe overrides.
+- Use `config/hbmConfig/hbmItemPools.json` for item pool overrides.
+- Keep template copies under version control for your server pack.
+- Use `/ntmreload` on a test server first; malformed JSON can interrupt gameplay.
+
+## Space and station administration
+
+Useful commands:
+
+```text
+/ntmstations list
+/ntmstations fetch <id|name>
+/ntmstations tp
+/ntmsatellites list
+/ntmsatellites descend <frequency>
+```
+
+Operational advice:
+
+- Keep a record of station names and owners.
+- Use `fetch` to recover or recreate a programmed station drive.
+- Test teleport behavior after dimension ID changes.
+- Avoid changing orbit dimension IDs after stations exist.
+
+## Performance notes
+
+High-load systems include explosions, fallout, atmosphere processing, worldgen, reactors, machines, and large item/fluid networks. Useful settings to review:
+
+- `1.42_threadedAtmospheres` for atmosphere performance.
+- Explosion lifespan, speed, fallout range, and chunk-loading settings in `06_explosions`.
+- Meteor and structure spawn rates for worldgen overhead.
+- Mob raid, glyphid, hive, infestation, and swarm options in `12_mobs`.
+
+## Backups
+
+Back up before:
+
+- Updating the mod.
+- Changing dimension IDs or biome IDs.
+- Enabling new worldgen on an existing world.
+- Testing reactors, nukes, or custom machines.
+- Activating custom recipe/fallout/fluid/loot JSON files.
+
+Minimum backup set:
+
+```text
+world/
+config/hbm.cfg
+config/hbmConfig/
+config/hbmRecipes/
+mods/RX-RNTM*.jar
+```
+
+## Known administration limitations
+
+- Many commands rely on vanilla/Forge permission behavior unless a permission level is explicitly implemented.
+- `/hbmbedrockdrop` edits the runtime excavator drop list; persistence is not clearly documented in code.
+- Several JSON systems generate templates with leading underscores; forgetting to remove the underscore is a common cause of changes not applying.
+- Legacy 1.7.10 server forks may alter ticking behavior and break machines.

--- a/docs/upstream-changes.md
+++ b/docs/upstream-changes.md
@@ -1,0 +1,89 @@
+# What Ragex's Nuclear Tech Changes from Original NTM
+
+Ragex's Nuclear Tech Mod is a fork of HBM's Nuclear Tech Mod with a different design target. Original NTM is a broad chaotic tech sandbox with many references, jokes, and fantasy systems. RNTM keeps the scale and danger but redirects the mod toward grounded nuclear technology, industrial chemistry, realistic resource processing, and plausible science-fiction where strict realism would not fit Minecraft gameplay.
+
+## Design direction
+
+RNTM was made to provide:
+
+- A stronger nuclear-engineering focus.
+- More realistic or plausible replacements for fantasy/unrealistic systems.
+- More chemistry, isotopes, industrial production, and periodic-table materials.
+- Rebalanced progression that asks players to use real industrial steps earlier.
+- More serious radiation, treatment, fallout, and contamination cleanup.
+- Server tools for controlling nuclear and missile warfare.
+- Compatibility and cleanup for modern 1.7.10 modpack environments such as Angelica and GTNH NEI forks.
+
+## Removed, reduced, or reworked fantasy elements
+
+RNTM intentionally removes or reduces systems that do not fit its grounded direction. Examples include removed or changed unrealistic recipes/features such as Power Fist recipes and the removed Nuclear Furnace recipe. The goal is not to delete all science-fiction content, but to keep science-fiction closer to real counterparts or plausible extensions of real technology.
+
+## Nuclear and radiation overhaul
+
+The RTM direction reworks nuclear gameplay around more realistic reactor and radiation behavior:
+
+- Reactor systems were reworked rather than treated as simple power blocks.
+- A **Molten Salt Reactor** was added.
+- WATZ was converted into a **Pebble Bed Reactor (PBR)** concept.
+- Research reactors were re-enabled in 528 mode.
+- Radiation mechanics and treatment systems were reworked.
+- Radiation-related treatments such as transplants, IVs, and Prussian Blue were updated.
+- Fallout can stack when areas are repeatedly irradiated.
+- Fallout debris is more difficult to clean up, making contaminated areas a longer-term problem.
+- Additional hazard sources were added across the mod.
+
+## Chemistry and materials
+
+RNTM expands the industrial side of the mod substantially:
+
+- Many new chemical processes and recipes were added.
+- Periodic-table coverage was expanded, excluding unstable synthetic elements where appropriate.
+- Distillation and isotope separation were reworked.
+- SILEX enrichment was adjusted toward a more realistic process.
+- Industrial production chains were expanded so materials have more grounded manufacturing paths.
+
+## World generation and space
+
+RNTM treats space and geology as part of the realism pass:
+
+- Planetary bodies were reworked.
+- Gas giant dimensions were added.
+- Travel to the Sun was added.
+- Planetary orbit calculations and broken time progression were fixed.
+- Oil deposits were moved toward bedrock-generated deposits.
+- Ore deposits were moved toward bedrock-generated deposits.
+- Atmosphere and water-table behavior are important gameplay rules, especially for space and planetary bodies.
+
+## Industry and progression
+
+Progression was changed to make industrial infrastructure matter earlier:
+
+- Steam systems were rebalanced.
+- Fluid production and handling were rebalanced.
+- Blast furnace use is emphasized earlier in progression.
+- Furnace smelting recipes were tweaked.
+- Additional RTG variants were added.
+- The Nuclear Furnace recipe was removed.
+
+## Weapons, warfare, and server controls
+
+RNTM keeps destructive content but gives servers clearer control points:
+
+- CIWS was re-added and reworked.
+- Bombsite support for CSGO Charge was added.
+- Scheduled nuclear/missile launch or enablement controls exist for server administration.
+- Some combat drop behavior was changed so beheading/flesh drops can occur from standard deaths.
+
+## Compatibility and cleanup
+
+RNTM also includes practical cleanup for modpack use:
+
+- Rendering and crash fixes for modern Angelica compatibility.
+- GTNH NEI fork compatibility work.
+- Removal of ShadyUtil.
+- Fertilizer tooltips and other usability improvements.
+- General balancing, optimization, cleanup, and many small fixes.
+
+## Documentation note
+
+The exact inherited-versus-reworked boundary can vary by release. When in doubt, check current recipes, generated configs, command behavior, and in-game names in this repository rather than assuming original NTM wiki behavior applies unchanged.


### PR DESCRIPTION
### Motivation

- Refocus and clarify this repository as Ragex's realism-oriented fork of HBM's Nuclear Tech Mod and provide clear user/server guidance.  
- Consolidate installation, configuration, command, and admin guidance so pack authors and server operators can safely deploy the mod.  
- Capture discovered commands, config behaviors, and documentation gaps discovered during a documentation pass.  

### Description

- Rewrote `README.md` to present RNTM goals, installation instructions, dependencies, configuration overview, commands summary, troubleshooting, and build instructions.  
- Added a documentation suite under `docs/`: `commands.md`, `configuration.md`, `getting-started.md`, `server-admin.md`, `upstream-changes.md`, and `documentation-audit.md` to document commands, config files, progression notes, upstream diffs, and outstanding documentation gaps.  
- Updated `changelog` to include the documentation changes and refocus notes about the README/docs.  
- Documented runtime behaviors and file locations such as `config/hbm.cfg`, `config/hbmConfig/`, `config/hbmRecipes/`, and commands like `/ntmreload`, `/ntmenablenukes`, `/ntmrad`, `/ntmstations`, and `/hbmbedrockdrop` for server operators.  

### Testing

- No automated tests were run as part of this documentation-focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a287c94a7308329b7cf2116bf4a6897)